### PR TITLE
Guard UISlider value updates

### DIFF
--- a/wurst/components/TableUiSliders.wurst
+++ b/wurst/components/TableUiSliders.wurst
@@ -103,6 +103,8 @@ public class UISlider
         return root
 
     ondestroy
+        if root != null
+            root.hide()
         if valueChangeFrameListener != null
             destroy valueChangeFrameListener
             valueChangeFrameListener = null

--- a/wurst/components/TableUiSliders.wurst
+++ b/wurst/components/TableUiSliders.wurst
@@ -18,9 +18,11 @@ public class UISlider
     private real width = 0.
     private string label = ""
     private SliderListener listener = null
+    private boolean syncingValue = false
     private framehandle root = null
     private framehandle sliderFrame = null
     private framehandle valueFrame = null
+    private FrameHandleListener valueChangeFrameListener = null
 
     construct(string label, real width, real minValue, real maxValue)
         this.label = label
@@ -48,7 +50,9 @@ public class UISlider
     function setValue(real newValue) returns thistype
         value = max(minValue, min(maxValue, newValue))
         if sliderFrame != null
+            syncingValue = true
             sliderFrame.setValue(value)
+            syncingValue = false
         if valueFrame != null
             valueFrame.setText(format(value))
         return this
@@ -77,10 +81,12 @@ public class UISlider
             ..setSize(max(0.034, width * 0.18), height)
             ..setTextAlignment(TEXT_JUSTIFY_MIDDLE, TEXT_JUSTIFY_RIGHT)
 
-        sliderFrame.onSliderValueChange() ->
-            value = BlzGetTriggerFrameValue()
+        valueChangeFrameListener = sliderFrame.onSliderValueChange() ->
+            let nextValue = BlzGetTriggerFrameValue()
+            let changed = nextValue != value
+            value = nextValue
             valueFrame.setText(format(value))
-            if listener != null
+            if changed and not syncingValue and listener != null
                 listener.onChange(value)
 
         let layout = new TableLayout(width, height, "Slider")
@@ -95,6 +101,11 @@ public class UISlider
         destroy layout
         defaultFrameParent = prevParent
         return root
+
+    ondestroy
+        if valueChangeFrameListener != null
+            destroy valueChangeFrameListener
+            valueChangeFrameListener = null
 
     function getFrame() returns framehandle
         return create()


### PR DESCRIPTION
## Summary
- Guard UISlider.setValue() from re-entrant native value-change callbacks.
- Ignore duplicate slider values before invoking consumer listeners.
- Retain and destroy the frame listener when the slider object is destroyed.

## Root cause
Programmatic slider synchronization could re-enter the public change callback through Warcraft's native slider event. Repeated identical native values also caused unnecessary listener work, and the frame listener was previously left registered after the component lifecycle ended. The component now separates internal value synchronization from user-driven changes and cleans up its listener.

## Validation
- grill typecheck --quiet
- grill test TableLayoutValidationTest --quiet