### PR TITLE
Make per-player UI a first-class API instead of a localPlayer block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,11 @@ If you are modifying a downstream map's `_build/dependencies/wurst-table-layout`
 - Create UI at elapsed time `0.00` or later; only TOC loading belongs in blocking `init`.
 - Create/get frame handles for all clients, cache them, and use owner-scoped show/hide for per-player UI.
 - Do not destroy Warcraft III frames in multiplayer cleanup. Hide and reuse them.
+- **Never write a `localPlayer` block around a library call.** Every component has `show(player)` / `hide(player)` / `setVisible(player, bool)` overloads that allocate for all clients first and then flip only that player's visibility flag. Same for the default HUD: `setResourceBarVisible(p, false)`, not `if localPlayer == p`. Visibility is the only state allowed to differ per client.
+- For UI each player must own independently (their own selection, their own dialog answer), build one tree per owner with `perPlayerFrames(...)` from `TableUiPerPlayer`. A single shared component is shared state: any player's click changes it for everyone.
+- `hideDefaultUi()` and everything in `MultiboardAttach` are global-only (they acquire handles, reparent frames, create a timer, and mutate synchronized multiboard state). They have no per-player form and must run identically on every client.
 - Do not create first-time frame handles inside `localPlayer` blocks.
+- Listener callbacks pass the acting `player` first (null when the change was programmatic). Use it instead of assuming the handler belongs to one player: a shared widget fires for everyone.
 - Do not use local UI getters (`getText`, `getValue`, `getWidth`, `getHeight`, `isVisible`, `BlzGetLocalClientWidth/Height`, etc.) as synced game logic or layout authority.
 - Build frames under their eventual parent with `withParent(...)` / `inLayer(...)`; for `panelTable()` / `cardTable()` use `layout.withContent(...)`. Avoid post-creation `setParent`, which leaves the frame in both parents' child lists and can misalign hit areas.
 - Keep ordinary roots in the strict safe band with `placeSafe(...)`; use `placeVisuallySafe(...)` only for deliberate sidecars/status UI where left idle-button overlap is acceptable.
@@ -32,6 +36,8 @@ If you are modifying a downstream map's `_build/dependencies/wurst-table-layout`
 - `wurst/TableLayout.wurst`: core layout engine, rows/cells, validation report, basic helpers.
 - `wurst/TableUi.wurst`: public facade exporting components.
 - `wurst/components/`: component implementations (`TableUiSafeArea`, dialogs, layers, panels, inputs, tooltips, etc.).
+- `wurst/components/TableUiPerPlayer.wurst`: `perPlayerFrames(...)` - one UI tree per owner, allocated on every client, with owner-scoped visibility.
+- `wurst/components/TableUiSyncCheck.wurst`: opt-in `checkUiSync()` desync diagnostic. Not re-exported by the `TableUi` facade; import it explicitly.
 - `wurst/MultiboardAttach.wurst`: custom content inside default multiboard shells.
 - `wurst/TableLayoutValidationTest.wurst`: headless layout/safe-area validation tests.
 - `wurst/TableLayoutTest.wurst`: manual visual demo; requires a real WC3 map run.

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -33,12 +33,15 @@ Before creating any UI, follow this order:
    Use `TableUiSimple`: `simpleBar` (native SIMPLESTATUSBAR fill + tint) and `simpleTexture` (tintable band art). These are SimpleFrames: they render BELOW all Frame-group UI, cannot be parented under panels, and can NEVER go inside `TableLayout` cells; place them absolutely with `placeAt`. For bars/images INSIDE layouts keep using `UIBar`/`statBar`/`img`.
 
 5. Need to hide or modify the DEFAULT Warcraft III UI (day/night clock, resource bar, menu buttons, minimap, portrait, hero bar, command card - or all of it)?
-   Use `TableUiDefaultUi`: named getters (`dayNightClock()`, `resourceBar()`, `commandButton(i)`, ...), `setXVisible(...)` helpers, `hideDefaultUi()` for fully custom-UI maps (treat as one-way), and `reserveDefaultUiHandles()` before any per-player show/hide. Do NOT hand-roll `BlzGetFrameByName`/child-index lookups; the package encodes the verified names, child indices and patch quirks. For multiboards, use `attachToMultiboard`.
+   Use `TableUiDefaultUi`: named getters (`dayNightClock()`, `resourceBar()`, `commandButton(i)`, ...), `setXVisible(bool)` helpers plus their `setXVisible(player, bool)` overloads for per-player HUD work, and `hideDefaultUi()` for fully custom-UI maps (treat as one-way, and global-only). Do NOT hand-roll `BlzGetFrameByName`/child-index lookups; the package encodes the verified names, child indices and patch quirks. For multiboards, use `attachToMultiboard` - global-only, it mutates synchronized multiboard state.
 
-6. Need FDF-only behavior?
+6. Should this UI differ per player?
+   Use the player-scoped overloads (`comp.show(p)`, `setResourceBarVisible(p, false)`) for "same UI, only some players see it", and `perPlayerFrames(...)` when each player needs their own instance. Do NOT write `if localPlayer == p` around a library call: that moves frame/trigger allocation into the local branch, which desyncs. Visibility is the only state allowed to differ per client.
+
+7. Need FDF-only behavior?
    Add a minimal reusable template to `imports/TableLayout.fdf`, then expose it through a Wurst helper in `TableUi.wurst` or `TableLayout.wurst`.
 
-7. Still need custom frame code?
+8. Still need custom frame code?
    Add a small reusable helper instead of inline one-off frame construction.
 
 Raw `BlzCreateFrame*` / `createFrameByType` code should be the last step, not the first draft.
@@ -60,7 +63,8 @@ Use these helpers instead of custom frame construction:
 - Navigation: `tabs(w, contentHeight)` (`addTab(title)` returns a content frame to build into, then `build()`)
 - Feedback: `UIBar`, `statBar`, `textArea`
 - HUD band / off-4:3 (SimpleFrames, never inside layouts): `simpleBar` (boss bar, tintable), `simpleTexture` (tintable band art)
-- Default WC3 UI: `hideDayNightClock`, `setResourceBarVisible`, `setMinimapVisible`, `hideDefaultUi`, `reserveDefaultUiHandles` (TableUiDefaultUi; never raw `BlzGetFrameByName` + child indices)
+- Default WC3 UI: `hideDayNightClock`, `setResourceBarVisible`, `setMinimapVisible`, `hideDefaultUi`, `reserveDefaultUiHandles` (TableUiDefaultUi; never raw `BlzGetFrameByName` + child indices). Each `setXVisible` also has a `(player, bool)` overload for per-player HUD work
+- Per-player UI: `comp.show(p)` / `comp.hide(p)` / `comp.setVisible(p, flag)` on every component; `perPlayerFrames(...)` (TableUiPerPlayer) when each player needs their own instance. **Never** write `if localPlayer == p` around a library call
 - Tooltips: `withTooltip`, `boxedTooltip`
 - Dialogs: `confirmDialog`, `closeButton` for the EscMenu-styled X close control; `dialog.closeButton()` on a `UIDialog` instance when a modal is attached (so the backdrop dismisses with the panel)
 - Multiboard UI: `attachToMultiboard`
@@ -318,6 +322,44 @@ d..withModal()..placeSafe(vec2(0.35, 0.45))..show()
 
 Use `confirmDialog` for ordinary yes/no UI. Native `DIALOG` is FDF-rigid and is usually unnecessary for map UI.
 
+To prompt a single player, use the player-scoped overload - never a `localPlayer` block:
+
+```wurst
+dialog.show(p)          // created for every client, visible only to p
+```
+
+The dialog is still one shared instance, so the first click resolves it and `onAccept(p)` reports who
+clicked. When each player must answer independently, give each their own (see below).
+
+### Per-player UI
+
+One shared component is shared state: any player's click changes it for everyone, and the callback runs
+on every client. When that is wrong, build one tree per owner. `perPlayerFrames` runs the factory once
+per owner on **every** client (so handle allocation stays identical) and gives you owner-scoped
+visibility, which is the only state allowed to differ:
+
+```wurst
+import TableUi
+
+UISelect array difficulty
+
+let picker = perPlayerFrames() owner ->
+    let s = select("Difficulty", 0.13)
+    ..addOption("Normal")..addOption("Hard")
+    ..onSelect((p, index, value) -> applyDifficulty(owner, index))
+    difficulty[owner.getId()] = s
+    return s.getFrame()
+
+picker.showEach()               // each player sees their own picker
+picker.hide(somePlayer)         // and only theirs can be hidden
+```
+
+Use `perPlayerFrames(owners, factory)` to build for an explicit list (a team, observers). Derive that
+list from synced state - slot/controller state, forces, map setup - never from a client-local value.
+
+To catch a divergence that slipped through, import `TableUiSyncCheck` and call `checkUiSync()`; it
+logs an error naming any player whose UI allocation count differs. Diagnostic only, never game logic.
+
 ### Stat Bar
 
 ```wurst
@@ -509,6 +551,8 @@ At runtime the library also warns automatically: a `Log.warn` fires once per cel
 - Is root placement done with `placeSafe(...)` or an explicitly documented safe-band coordinate?
 - Is all custom frame creation/manipulation delayed until after map load (`doAfter(0.)` or later), with only TOC loading in `init`?
 - Does the layout avoid `BlzGetLocalClientWidth()` / `BlzGetLocalClientHeight()` and other local frame getters for sizing/placement decisions?
+- Is there a `localPlayer` block anywhere around a library call? There should not be: use `comp.show(p)` / `setXVisible(p, ...)` / `perPlayerFrames(...)` instead.
+- Does any listener assume it belongs to one player? Handlers run on every client for a click by any player - check the `player` argument or build per-player instances.
 - Are tooltips created through `withTooltip` or `boxedTooltip`?
 - Library buttons release keyboard focus automatically; for any clickable frame the library did NOT create, did it get `onClickReleaseFocus()` (or `disable()` if decorative)?
 - If multiboard code changed, was minimize/maximize considered?

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -354,8 +354,12 @@ picker.showEach()               // each player sees their own picker
 picker.hide(somePlayer)         // and only theirs can be hidden
 ```
 
-Use `perPlayerFrames(owners, factory)` to build for an explicit list (a team, observers). Derive that
-list from synced state - slot/controller state, forces, map setup - never from a client-local value.
+Use `perPlayerFrames(owners, factory)` with an `ArrayList<player>` (e.g. `asArrayList(p1, p2)`) to
+build for an explicit set - a team, observers. Derive that list from synced state - slot/controller
+state, forces, map setup - never from a client-local value.
+
+Each root is created globally hidden, so a player only ever sees a tree explicitly shown to them; the
+factory does not need to hide what it builds.
 
 To catch a divergence that slipped through, import `TableUiSyncCheck` and call `checkUiSync()`; it
 logs an error naming any player whose UI allocation count differs. Diagnostic only, never game logic.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It began as a table/flexbox layout (rows → cells → framehandles, with option
   See the [universal font glyph guide](UNIVERSAL_FONT_GLYPHS.md) for the verified catalog and setup notes.
 - **SimpleFrame helpers**: `simpleBar` (boss/HUD bars with native fill + runtime tinting) and `simpleTexture` (tintable, full-width band art) for what Frame-group UI cannot do.
 - **Default-HUD control**: hide or modify the day/night clock, resource bar, menu buttons, minimap, portrait, hero bar and command card by name (`TableUiDefaultUi`), attach custom content to a self-healing native multiboard shell (`attachToMultiboard`), or go fully custom-UI with `hideDefaultUi()`.
+- **Per-player UI without desync risk**: every component has `show(player)` / `hide(player)` / `setVisible(player, bool)` overloads that allocate for all clients and then flip only that player's visibility flag, and `perPlayerFrames(...)` builds one tree per owner when players need independent instances. You should never write a `localPlayer` block; an opt-in `checkUiSync()` diagnostic catches it if you did.
 - **Sane defaults**: a spacing scale (`SPACE_*`), automatic component minimums, automatic keyboard-focus release, a container hierarchy, and safe-area placement that keeps panels clear of the melee HUD.
 - **Built-in validation**: `checkFits()` / `inspect()` catch overflow and unsized cells, at runtime and headless in `grill test`.
 - **Agent support**: ships agent instruction files (decision tree, recipes, verified WC3 frame rules) and a headless feedback loop, so an LLM can generate correct UI on the first try (see [AI readiness](#ai-readiness)).
@@ -250,6 +251,47 @@ new TableLayout(0.5, 0.25)
 ..createFrame()
 ```
 
+## Per-player UI
+
+Warcraft III is lockstep: frames must be **allocated** identically on every client, and only the
+visibility flag may differ per player. So the tempting shortcut is the one thing you must not write:
+
+```
+if localPlayer == p
+    dialog.show()          // WRONG: creates frames + click triggers on ONE client
+```
+
+Frame events are synced, so that button's click fires on every client - but only the client that
+created it resolves a listener and runs your callback. Instead, every component takes the player
+directly. These allocate for all clients first, then flip only that player's visibility flag:
+
+```
+dialog.show(p)
+volumeSlider.hide(p)
+statusBar.setVisible(p, false)
+setResourceBarVisible(p, false)     // same shape for the default HUD
+```
+
+A single component is shared state: any player's click changes it for everyone, and every listener
+reports who acted (`onSelect(p, index, value)`, `onChange(p, value)`, ...; `p` is null when the
+change was programmatic). When players need genuinely independent instances, build one tree per
+owner - `perPlayerFrames` runs the factory once per owner on **every** client:
+
+```
+UISelect array difficulty
+
+let picker = perPlayerFrames() owner ->
+    let s = select("Difficulty", 0.13)..addOption("Normal")..addOption("Hard")
+    difficulty[owner.getId()] = s
+    return s.getFrame()
+
+picker.showEach()                   // each player sees their own, nobody sees anyone else's
+```
+
+`import TableUiSyncCheck` and call `checkUiSync()` to verify: it asks every player for their UI
+allocation count and logs an error naming any player whose count differs. It is a diagnostic - never
+branch game logic on it.
+
 ## Higher-level UI helpers
 
 For common UI, import `TableUi` and use its small component helpers on top of `TableLayout`.
@@ -305,7 +347,17 @@ setMinimapVisible(false)
 hideDefaultUi()
 ```
 
-Individual elements: `dayNightClock()`, `resourceBar()`, `upperButtonBar()`, `minimapFrame()`, `portraitFrame()`, `heroBar()`, `commandButton(0..11)`, `inventoryButton(0..5)`, each with a `setXVisible` helper. Call `reserveDefaultUiHandles()` once at elapsed `0.` before any per-player (local) show/hide. The quirks (command buttons reappearing on selection, menu hotkeys surviving a hide, Reforged 2.0 console changes) are documented in [`WC3_FRAMEHANDLE_GUIDE.md`](WC3_FRAMEHANDLE_GUIDE.md).
+Individual elements: `dayNightClock()`, `resourceBar()`, `upperButtonBar()`, `minimapFrame()`, `portraitFrame()`, `heroBar()`, `commandButton(0..11)`, `inventoryButton(0..5)`, each with a `setXVisible` helper.
+
+For a per-player HUD, use the `(player, bool)` overload rather than a local block - it acquires the handle for every client and only then applies that player's visibility flag:
+
+```
+setResourceBarVisible(observer, false)
+setMinimapVisible(observer, false)
+hideDayNightClock(observer)
+```
+
+`hideDefaultUi()` has no per-player form on purpose: it reparents frames and resizes the console backdrop, so it must run identically everywhere. Call it for everyone, then differentiate with the setters above. `reserveDefaultUiHandles()` remains available for hand-written local blocks against raw default frames. The quirks (command buttons reappearing on selection, menu hotkeys surviving a hide, Reforged 2.0 console changes) are documented in [`WC3_FRAMEHANDLE_GUIDE.md`](WC3_FRAMEHANDLE_GUIDE.md).
 
 Layout additions such as `gap`, `growY`, `minWidth`, `minHeight`, `fixedWidth`, `fixedHeight`, and `fixedSize` are opt-in and do not alter existing layouts unless called.
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ statusBar.setVisible(p, false)
 setResourceBarVisible(p, false)     // same shape for the default HUD
 ```
 
+`show(player)` is exclusive on first use: components are created visible (right for the ordinary
+"add it to a layout" flow), so the first player-scoped show hides the frame from everyone else before
+revealing it. Later scoped calls are additive, so `show(p1)` then `show(p2)` leaves exactly those two.
+`framehandle.setVisibleForOwner(player, bool)` gives your own frames the same behaviour.
+
 A single component is shared state: any player's click changes it for everyone, and every listener
 reports who acted (`onSelect(p, index, value)`, `onChange(p, value)`, ...; `p` is null when the
 change was programmatic). When players need genuinely independent instances, build one tree per

--- a/WC3_FRAMEHANDLE_GUIDE.md
+++ b/WC3_FRAMEHANDLE_GUIDE.md
@@ -377,6 +377,21 @@ Why the wrong version is not just cosmetic: frame events are synced, so the clic
 client, but only the client that ran `create()` resolves a listener for it. The map's callback then
 executes on exactly one machine - a local branch reaching a synchronized sink.
 
+**`show(player)` is exclusive on first use.** Component roots are created *visible*, which is right
+for the ordinary flow (build it, add it to a layout, everyone sees it) but wrong for per-player UI:
+`BlzFrameSetVisible` under a local guard only touches that player's client, so showing a
+default-visible frame to one player would leave it on every other screen untouched. The first
+player-scoped show therefore hides the frame globally first, then reveals it to that player. Later
+scoped calls are additive, so a set still works:
+
+```wurst
+panel.show(p1)          // p1 only - everyone else loses it
+panel.show(p2)          // now exactly p1 and p2
+panel.hide(p1)          // now p2 only
+```
+
+`framehandle.setVisibleForOwner(player, bool)` exposes the same behaviour for your own frames.
+
 When each player needs UI they own independently, build one tree per owner instead of diverging one
 shared tree (`TableUiPerPlayer`):
 

--- a/WC3_FRAMEHANDLE_GUIDE.md
+++ b/WC3_FRAMEHANDLE_GUIDE.md
@@ -327,6 +327,18 @@ Available wrappers include `onClick`, `onMouseEnter`, `onMouseLeave`, `onSliderV
 
 Frame events are synchronized. For game-affecting input, read the event data inside the event and store it in synced/player-indexed state. Do not read local UI getters later and use them for synced game logic.
 
+Two consequences worth internalising, because they surprise people in opposite directions:
+
+- **A handler runs on every client, for a click by any player.** One shared widget means player 12 can
+  fire the callback that "belongs" to player 1. Every library listener therefore passes the acting
+  `player` first (`onSelect(p, index, value)`, `onChange(p, value)`, ...); it is null when the change
+  was programmatic rather than a click. Check it, or build per-player instances.
+- **Widget state a player changes by hand is still local.** Dragging a slider moves the knob only on
+  the dragging client, even though `SLIDER_VALUE_CHANGED` reaches everyone with the same value; the
+  same goes for text typed into an edit box. Re-assert such state from inside the (synced) event on
+  every client - `UISlider` does exactly this - and read the value from `BlzGetTriggerFrameValue()` /
+  `BlzGetTriggerFrameText()`, never from `BlzFrameGetValue` / `BlzFrameGetText`.
+
 ### Keyboard focus
 
 Clicked frames steal keyboard focus, and a focused frame swallows the **Enter** key. Because Enter normally opens chat, a stray focus means Enter either does nothing (chat won't open) or re-fires the focused control, which can be destructive (an accidental button press). This affects buttons, edit boxes and even clickable backdrops (e.g. Blizzard's chat window).
@@ -345,6 +357,40 @@ How this library handles it:
 ## Multiplayer Safety
 
 WC3 is lockstep. UI visuals may be local, but handle allocation and game-affecting results must remain deterministic.
+
+**With this library you should not be writing `localPlayer` blocks at all.** Every component exposes
+player-scoped overloads that do the allocation for all clients and then flip only that player's
+visibility flag, so the unsafe shape is not reachable through the normal API:
+
+```wurst
+// Right: one allocation for everyone, one local flag.
+dialog.show(p)
+volumeSlider.hide(p)
+setResourceBarVisible(p, false)
+
+// Wrong: the allocation moves inside the local branch.
+if localPlayer == p
+    dialog.show()            // creates frames, click triggers and listener closures on ONE client
+```
+
+Why the wrong version is not just cosmetic: frame events are synced, so the click fires on every
+client, but only the client that ran `create()` resolves a listener for it. The map's callback then
+executes on exactly one machine - a local branch reaching a synchronized sink.
+
+When each player needs UI they own independently, build one tree per owner instead of diverging one
+shared tree (`TableUiPerPlayer`):
+
+```wurst
+UISelect array difficulty
+
+let picker = perPlayerFrames() owner ->
+    let s = select("Difficulty", 0.13)..addOption("Normal")..addOption("Hard")
+    difficulty[owner.getId()] = s
+    return s.getFrame()
+picker.showEach()            // every player sees their own, nobody sees anyone else's
+```
+
+If you do reach past the library to a raw frame, the classic rules still apply.
 
 Safe pattern:
 
@@ -367,12 +413,29 @@ Rules:
 - Do not create/get first-time UI handles only inside a local-player block.
 - Do not destroy UI frames in MP code; use `hide()`.
 - Do not use local UI state getters as synced data sources.
-- Create all per-player copies for all players, then hide/show locally.
+- Create all per-player copies for all players, then hide/show locally (`perPlayerFrames(...)` does this for you).
 - Cache handles. Do not repeatedly create duplicate UI.
+- Prefer the `show(player)` / `hide(player)` / `setVisible(player, bool)` overloads over hand-written local blocks; they put the allocation on the safe side of the guard by construction.
+- `hideDefaultUi()` and the `MultiboardAttach` functions are global-only: they acquire handles, reparent frames, create a timer and mutate synchronized multiboard state. Never scope them to a player.
 
 Be careful with these getters in MP because their values can differ locally: `getText`, `getValue`, `isEnabled`, `getAlpha`, `getHeight`, `getWidth`, `getParent`, `isVisible`, `BlzGetLocalClientWidth()`, and `BlzGetLocalClientHeight()`.
 
 **The handleId reservation pattern** (the safe way to touch frames locally): acquire every frame handle once, synchronously for all players (as in the safe pattern above). Once the handle exists in the map script, getting and using that frame inside a `localPlayer` block no longer allocates a handleId, so it cannot desync handle counters. The unsafe pattern is unsafe precisely because the FIRST acquisition happens locally.
+
+**Detecting a divergence you already shipped.** `TableUiSyncCheck` (opt-in import; not re-exported by
+the `TableUi` facade) asks every ingame player for their library UI allocation count and logs an error
+naming the counts when they disagree - the signature of a tree built inside a local block:
+
+```wurst
+import TableUiSyncCheck
+...
+doAfter(5.) -> checkUiSync()
+```
+
+It is a diagnostic and runs asynchronously (the counts arrive over the network). Never branch game
+logic on its result. It covers library container/component allocation (`layoutFrame` /
+`nextUiContext`), which is what per-player UI is built from; a bare `p()` / `img()` / `btn()` created
+inside a local block is not counted.
 
 **Frames that do not exist until locally triggered** are a handleId trap: quest dialog frames only exist after the quest button was clicked, chat frames only exist in multiplayer, the log dialog only in single player, and the portrait HP text only after a unit was selected. Touching these "on demand" acquires handles at different times on different clients. If you must use one, force-create it synchronously for everyone first (e.g. `BlzFrameClick` on the quest button) or avoid it entirely; this library builds its own panels instead.
 
@@ -405,7 +468,8 @@ Use `TableUiDefaultUi` instead of memorising frame names, child indices and patc
 - `dayNightClock()` / `hideDayNightClock()` / `setDayNightClockVisible(bool)`: the clock has **no frame name**; it is `GAME_UI` child `[5]` child `[0]`, reachable only on 1.32.6+. Never hide its *parent* `[5]`: that is also the minimap's ancestor.
 - `resourceBar()`, `upperButtonBar()`, `minimapFrame()`, `portraitFrame()`, `heroBar()`, `commandButton(0..11)`, `inventoryButton(0..5)` with matching `setXVisible(bool)` helpers.
 - `hideDefaultUi()`: the full custom-UI recipe (`enableUIAutoPosition(false)` + `BlzHideOriginFrames` + collapsing `ConsoleUIBackdrop` to `0 x 0.0001` rather than hiding it + hiding the invisible mouse dead zone at the command card + on Reforged 2.0 also the `ConsoleTopBar`/`ConsoleBottomBar` art, reparenting the tooltip frame out first so tooltips survive).
-- `reserveDefaultUiHandles()`: touches every handle once, synchronously: call it at elapsed 0.00 for all players BEFORE any per-player (`localPlayer`) show/hide of default UI.
+- `setXVisible(player, bool)` overloads on every helper (`setResourceBarVisible(p, false)`, `setMinimapVisible(p, false)`, `hideDayNightClock(p)`, ...): they acquire the handle for all clients and then apply only that player's visibility flag. This is the per-player HUD path; do not wrap them in a `localPlayer` block. All of them tolerate a frame missing on the running patch.
+- `reserveDefaultUiHandles()`: touches every handle once, synchronously. With the player-scoped overloads this is belt-and-braces rather than load-bearing; it stays the right call at elapsed 0.00 when you hand-write a `localPlayer` block against a raw default frame.
 
 Facts that shape correct usage (do not fight these):
 
@@ -415,7 +479,8 @@ Facts that shape correct usage (do not fight these):
 - **Hiding the upper menu buttons does not disable their hotkeys** (F9-F12); disable the button frames to stop those, and note the game re-enables them whenever a menu closes.
 - **The portrait uses whole-screen coordinates**, not the 4:3 system.
 - **Never hide `"InventoryText"`'s parent** (GAME_UI child `[4]`): it makes ALL SimpleFrames invisible yet still clickable.
-- Visibility changes on default frames are local-state and safe per-player AFTER handles are reserved; handle acquisition inside `localPlayer` blocks desyncs.
+- Visibility changes on default frames are local-state and safe per-player AFTER handles are reserved; handle acquisition inside `localPlayer` blocks desyncs. The `setXVisible(player, bool)` overloads reserve then apply in one call, which is why they are the recommended path.
+- **`hideDefaultUi()` is not per-player.** It calls `enableUIAutoPosition(false)`, reparents the ubertooltip and resizes the console backdrop - shared structural work. Call it for everyone, then differentiate with the player-scoped setters.
 
 ## Multiboard Attach
 
@@ -466,7 +531,7 @@ button.setTooltip(tooltip)
 
 Cautions:
 
-- `setTooltip` cannot really be undone.
+- `setTooltip` cannot really be undone. `removeTooltip()` / `clearTooltips()` therefore only hide the tooltip box (which is what stops it rendering); they deliberately do not clear the owner association, because re-setting the pair is the documented way to crash on hover.
 - Calling `setTooltip` twice with the same frame/tooltip pair can crash on hover.
 - Prefer per-tooltip frames when styled text matters.
 - Disable tooltip text/backdrops if they should not capture mouse input.

--- a/WC3_FRAMEHANDLE_GUIDE.md
+++ b/WC3_FRAMEHANDLE_GUIDE.md
@@ -390,6 +390,10 @@ panel.show(p2)          // now exactly p1 and p2
 panel.hide(p1)          // now p2 only
 ```
 
+A first scoped **hide** is subtractive instead: `panel.hide(p)` on a still-global panel means "take it
+away from p", not "take it away from everyone", so a later `panel.show(p)` restores that player
+without disturbing anyone else.
+
 `framehandle.setVisibleForOwner(player, bool)` exposes the same behaviour for your own frames.
 
 When each player needs UI they own independently, build one tree per owner instead of diverging one

--- a/wurst/MultiboardAttach.wurst
+++ b/wurst/MultiboardAttach.wurst
@@ -7,6 +7,16 @@ import TableLayout
     Attach custom content to the existing multiboard UI (reuse maximize/minimize behavior).
     The native multiboard backdrop remains the single panel background.
 
+    MULTIPLAYER - THIS PACKAGE IS NOT PER-PLAYER. Unlike the rest of the library it does not deal in
+    frames alone: multiboard row count and item style (MultiboardSetRowCount / MultiboardSetItemsStyle)
+    are SYNCHRONIZED game state, and the refresh ticker is a timer handle created on first attach.
+    Every attach/refresh function here must therefore run identically on every client. Never call one
+    inside a localPlayer block, and never make an attach conditional on client-local state.
+
+    To show a board to only some players, attach it for everyone and scope the native multiboard's own
+    visibility per player (multiboard display is player-scoped by the engine), or build a map-owned
+    panel with panelTable() and perPlayerFrames() instead.
+
     Non-TableLayout callers must provide an accurate content height. Table layouts should use
     attachTableLayoutToMultiboard(), which measures their rows and padding.
 

--- a/wurst/TableLayout.wurst
+++ b/wurst/TableLayout.wurst
@@ -51,19 +51,26 @@ public function uiAllocationCount() returns int
 // setVisible(p, flag) only ever touches p's client, so showing a default-visible frame to one player
 // leaves it on every OTHER player's screen untouched - i.e. still visible to everyone.
 //
-// So the FIRST player-scoped show takes the frame out of that "everyone" default by hiding it
+// So the FIRST player-scoped SHOW takes the frame out of that "everyone" default by hiding it
 // globally, then reveals it to the requested player. Later scoped calls are additive, so showing to a
 // set of players still works (show(p1); show(p2) leaves exactly p1 and p2). A global show()/hide() is
 // untouched, so the ordinary layout flow behaves exactly as before.
+//
+// A first scoped HIDE is different: hide(p) on a globally visible frame means "take it away from p",
+// not "take it away from everyone", so it must NOT trigger the global hide. It still marks the frame
+// as owner-scoped, otherwise a later show(p) restoring that player would be mistaken for a first show
+// and would yank the frame off every other screen.
 constant ownerScopedFrames = new HashMap<framehandle, bool>
 
-/** Shows or hides `this` for ONE player, hiding it from everyone else first if this is the frame's
-    first player-scoped show. The frame must already exist on every client - allocate outside any
-    local-player branch. This is the only frame state allowed to differ between clients. */
+/** Shows or hides `this` for ONE player. On the frame's first player-scoped SHOW it is hidden from
+    everyone else first, so a component created visible does not stay on every screen; a first scoped
+    HIDE is subtractive and leaves other players alone. The frame must already exist on every client -
+    allocate outside any local-player branch. This is the only frame state allowed to differ. */
 public function framehandle.setVisibleForOwner(player p, bool flag)
-    if flag and not ownerScopedFrames.has(this)
+    if not ownerScopedFrames.has(this)
         ownerScopedFrames.put(this, true)
-        this.hide()
+        if flag
+            this.hide()
     this.setVisible(p, flag)
 
 // --- Focus -------------------------------------------------------------------

--- a/wurst/TableLayout.wurst
+++ b/wurst/TableLayout.wurst
@@ -29,9 +29,20 @@ public var legacyGapMath = false
 // Frames are stored by (name, createContext); use a fresh context per repeated/instanced frame so
 // copies do not collide. nextUiContext() hands out monotonically increasing contexts.
 var nextCreateContext = 1000
+// Counts library container / component allocations on THIS client. Every client must land on the same
+// number: a differing count means a frame tree was built inside a localPlayer block, which desyncs
+// handle allocation. TableUiSyncCheck.checkUiSync() compares it across players.
+var uiAllocations = 0
+
 public function nextUiContext() returns int
     nextCreateContext++
+    uiAllocations++
     return nextCreateContext
+
+/** Number of container / component frames this client has allocated through the library. Compare it
+    across clients with TableUiSyncCheck.checkUiSync(); it is a diagnostic, never game logic. */
+public function uiAllocationCount() returns int
+    return uiAllocations
 
 // --- Focus -------------------------------------------------------------------
 // When true (default), clickable presets (btn / imgBtn / iconButton / textButton /
@@ -963,6 +974,7 @@ public class LayoutReport
         textOverflowSummary += "[row " + rowIndex + " cell " + cellIndex + "] estimated text width " + estimatedWidth + " exceeds cell width " + cellWidth + " for \"" + text + "\"; "
 
 public function layoutFrame(framehandle parent) returns framehandle
+    uiAllocations++
     return createFrame("FRAME", "multiboardFrame", parent, null, 0)
 
 public function defaultFrame() returns framehandle

--- a/wurst/TableLayout.wurst
+++ b/wurst/TableLayout.wurst
@@ -1,6 +1,7 @@
 package TableLayout
 import public ClosureFrames
 import LinkedList
+import HashMap
 import TableUiTextMetrics
 
 /*
@@ -43,6 +44,27 @@ public function nextUiContext() returns int
     across clients with TableUiSyncCheck.checkUiSync(); it is a diagnostic, never game logic. */
 public function uiAllocationCount() returns int
     return uiAllocations
+
+// --- Player-scoped visibility -------------------------------------------------
+// Component roots are created VISIBLE, which is correct for the ordinary flow: build it, add it to a
+// layout, every player sees it. Per-player UI needs the opposite starting point, and the two collide:
+// setVisible(p, flag) only ever touches p's client, so showing a default-visible frame to one player
+// leaves it on every OTHER player's screen untouched - i.e. still visible to everyone.
+//
+// So the FIRST player-scoped show takes the frame out of that "everyone" default by hiding it
+// globally, then reveals it to the requested player. Later scoped calls are additive, so showing to a
+// set of players still works (show(p1); show(p2) leaves exactly p1 and p2). A global show()/hide() is
+// untouched, so the ordinary layout flow behaves exactly as before.
+constant ownerScopedFrames = new HashMap<framehandle, bool>
+
+/** Shows or hides `this` for ONE player, hiding it from everyone else first if this is the frame's
+    first player-scoped show. The frame must already exist on every client - allocate outside any
+    local-player branch. This is the only frame state allowed to differ between clients. */
+public function framehandle.setVisibleForOwner(player p, bool flag)
+    if flag and not ownerScopedFrames.has(this)
+        ownerScopedFrames.put(this, true)
+        this.hide()
+    this.setVisible(p, flag)
 
 // --- Focus -------------------------------------------------------------------
 // When true (default), clickable presets (btn / imgBtn / iconButton / textButton /

--- a/wurst/TableLayoutTest.wurst
+++ b/wurst/TableLayoutTest.wurst
@@ -24,6 +24,7 @@ init
         let custom = buildCustomDialog()
 
         buildComponentsPanel(confirm, custom)
+        buildPerPlayerDemo()
         buildDisplayPanel()
         buildTypographyPanel()
         buildShowcasePanel()
@@ -124,6 +125,34 @@ function buildComponentsPanel(UIConfirmDialog confirm, UIDialog custom)
 
     doPeriodically(0.03) cb ->
         bar.setValue((1 + currentTime.cos()) / 2.)
+
+// ===== Per-player UI (TableUiPerPlayer): one tree per owner, owner-scoped visibility =====
+// Visual check: each player sees exactly ONE card, naming themselves. In a single-player run that is
+// P1's card and nothing else. The point is what you CANNOT see: every owner's card is allocated on
+// every client, in the same order, so the only thing that differs per player is the visibility flag.
+// This is the shape to copy instead of building a tree inside a localPlayer block.
+function buildPerPlayerDemo()
+    let cw = 0.17
+    let chh = 0.052
+    let inner = cw - 2. * PANEL_BORDER_INSET
+    let ui = perPlayerFrames() owner ->
+        let root = card(cw, chh)
+        let prev = defaultFrameParent
+        defaultFrameParent = root
+        let l = new TableLayout(cw, chh, "PerPlayerCard")
+        l.padding = padding(PANEL_BORDER_INSET, PANEL_BORDER_INSET, PANEL_BORDER_INSET, PANEL_BORDER_INSET)
+        l.gap(0, 0.003)
+        l
+        ..row()..add(h5("Private panel")..setSize(inner, 0.014))..growX()
+        ..row()..add(p(accent(owner.getName()))..setSize(inner, 0.014))..growX()
+        l.applyTo(root)
+        destroy l
+        root.placeSafe(vec2(0.60, 0.30), cw, chh)
+        root.disable()
+        defaultFrameParent = prev
+        return root
+    // Every owner sees their own card and nobody else's. No localPlayer block anywhere.
+    ui.showEach()
 
 // A custom tooltip BUILT FROM FRAMES (icon + heading + body, each its own size), not just a string.
 // Created hidden in the OVERLAY band, anchored above its owner, then attached with setTooltip so WC3
@@ -289,7 +318,7 @@ function buildShowcasePanel()
     let woodCard = barCard("Lumber", lumber("640"), woodBar, cardW)
     cardGroup.add(goldCard).setSelected(true)   // pre-select one so it is obvious the cards are clickable
     cardGroup.add(woodCard)
-    cardGroup.onSelect(idx -> print("|cff40ff40clicked card " + idx + " while its bar animates -> overlay still works|r"))
+    cardGroup.onSelect((clicker, idx) -> print("|cff40ff40" + clicker.getName() + " clicked card " + idx + " while its bar animates -> overlay still works|r"))
     let statsLayout = new TableLayout(inner, 0.058, "StatsTab")
     statsLayout.padding = padding(0.002, 0.002, 0.002, 0.002)
     statsLayout.gap(0.004, 0)

--- a/wurst/TableUi.wurst
+++ b/wurst/TableUi.wurst
@@ -26,3 +26,6 @@ import public TableUiTabs
 import public TableUiCards
 import public TableUiSimple
 import public TableUiDefaultUi
+import public TableUiPerPlayer
+// TableUiSyncCheck is deliberately NOT re-exported: importing it registers stdlib sync events, so
+// only maps that want the desync diagnostic pay for it. `import TableUiSyncCheck` to opt in.

--- a/wurst/components/TableUiBars.wurst
+++ b/wurst/components/TableUiBars.wurst
@@ -67,6 +67,20 @@ public class UIBar
         if frame != null
             applyValue()
 
+    function getFrame() returns framehandle
+        return create()
+
+    /** Shows or hides the bar FOR ONE PLAYER. Creates it on every client first, then flips only that
+        player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag)
+        create().setVisible(p, flag)
+
+    function show(player p)
+        setVisible(p, true)
+
+    function hide(player p)
+        setVisible(p, false)
+
 // --- Stat bar ----------------------------------------------------------------
 // A labelled bar: [label .......... value] over [====fill====].
 
@@ -130,6 +144,18 @@ public class UIStatBar
 
     function getFrame() returns framehandle
         return create()
+
+    /** Shows or hides the stat bar FOR ONE PLAYER. Creates it on every client first, then flips only
+        that player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
 
 public function statBar(string label, real width) returns UIStatBar
     return new UIStatBar(label, width)

--- a/wurst/components/TableUiBars.wurst
+++ b/wurst/components/TableUiBars.wurst
@@ -73,7 +73,7 @@ public class UIBar
     /** Shows or hides the bar FOR ONE PLAYER. Creates it on every client first, then flips only that
         player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag)
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
 
     function show(player p)
         setVisible(p, true)
@@ -148,7 +148,7 @@ public class UIStatBar
     /** Shows or hides the stat bar FOR ONE PLAYER. Creates it on every client first, then flips only
         that player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiButtons.wurst
+++ b/wurst/components/TableUiButtons.wurst
@@ -116,7 +116,7 @@ public class UICheckbox
         NOTE: the checked state stays shared - a click by any player toggles it for everyone. */
     function setVisible(player p, bool flag) returns thistype
         if bg != null
-            bg.setVisible(p, flag)
+            bg.setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiButtons.wurst
+++ b/wurst/components/TableUiButtons.wurst
@@ -65,8 +65,9 @@ function imgBtnFrame(string path, real width, real height) returns framehandle
     return imgBtnFrame(defaultFrameParent, path, width, height)
 
 
-interface CheckboxListener
-    function onChange(boolean checked)
+/** `p` is the player who clicked, or null when the state came from setChecked(). */
+public interface CheckboxListener
+    function onChange(player p, boolean checked)
 
 public class UICheckbox
     private var value = false
@@ -93,7 +94,7 @@ public class UICheckbox
                 check.hide()
 
             if listener != null
-                listener.onChange(value)
+                listener.onChange(GetTriggerPlayer(), value)
 
         // Create the check overlay UNDER bg from the start, instead of under the ambient defaultFrameParent
         // and then ..setParent(bg). A post-creation setParent leaves the frame in both parents' child
@@ -109,6 +110,20 @@ public class UICheckbox
 
     function getFrame() returns framehandle
         return bg
+
+    /** Shows or hides the checkbox FOR ONE PLAYER. The frames already exist on every client (they are
+        built in the constructor), so this only flips that player's visibility flag.
+        NOTE: the checked state stays shared - a click by any player toggles it for everyone. */
+    function setVisible(player p, bool flag) returns thistype
+        if bg != null
+            bg.setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
 
     function setChecked(boolean value)
         this.value = value

--- a/wurst/components/TableUiDefaultUi.wurst
+++ b/wurst/components/TableUiDefaultUi.wurst
@@ -7,9 +7,11 @@ package TableUiDefaultUi
 // RULES (these are WC3 facts, not style):
 //   - Call these at elapsed time 0.00+, not in blocking init (frames mis-pose / crash at init).
 //   - Handle acquisition must happen synchronously for ALL players. Every getter here caches its
-//     handle on first call; if you plan per-player (localPlayer) show/hide, call
-//     reserveDefaultUiHandles() once for everyone first, then BlzFrameSetVisible-style changes
-//     inside localPlayer blocks are safe (visuals may differ per player; handles may not).
+//     handle on first call. For per-player HUD work use the setXVisible(player, bool) overloads:
+//     they acquire the handle for every client and only then apply the local visibility flag, so
+//     there is nothing left to get wrong. Do NOT wrap them in a localPlayer block - that puts the
+//     acquisition back inside the local branch, which is the actual desync. reserveDefaultUiHandles()
+//     stays available for hand-written local blocks against raw frames.
 //   - Command card / inventory buttons REAPPEAR on every unit selection, even while hidden via
 //     BlzHideOriginFrames. A one-shot hide of those is not permanent; re-hide on selection.
 //   - Hiding a container hides its children, and a child cannot be shown while its container is
@@ -30,6 +32,9 @@ framehandle upperButtonBarFrame = null
 framehandle cachedMinimap = null
 framehandle cachedPortrait = null
 framehandle heroBarFrame = null
+framehandle minimapButtonBarFrame = null
+framehandle array commandButtonFrame
+framehandle array inventoryButtonFrame
 
 /** The day/night cycle dial. It has NO frame name: it is GAME_UI child [5] -> child [0]
     (1.32.6+ only; returns null before that). Its parent [5] is ALSO the minimap's ancestor,
@@ -78,18 +83,40 @@ public function heroBar() returns framehandle
         heroBarFrame = getOriginFrame(ORIGIN_FRAME_HERO_BAR)
     return heroBarFrame
 
+/** The five minimap filter buttons' container ("MiniMapButtonBar"). */
+public function minimapButtonBar() returns framehandle
+    if minimapButtonBarFrame == null
+        minimapButtonBarFrame = getFrame("MiniMapButtonBar") // in stdlib FramehandleDefaultNames upstream
+    return minimapButtonBarFrame
+
 /** Command card button 0..11 ("CommandButton_N", 1.32+): 0 is top-left, 11 bottom-right. Move/hide
     via these named frames (the origin frames glitch when moved in 1.32+). They reappear/update on
-    every unit selection. */
+    every unit selection. Cached, so a re-hide loop on selection events never re-acquires a handle. */
 public function commandButton(int index) returns framehandle
-    return getFrame("CommandButton_" + index)
+    if index < 0 or index > 11
+        return null
+    if commandButtonFrame[index] == null
+        commandButtonFrame[index] = getFrame("CommandButton_" + index)
+    return commandButtonFrame[index]
 
 /** Inventory item button 0..5 ("InventoryButton_N", 1.32+). Same reappear-on-selection rule as
-    command buttons. */
+    command buttons. Cached, like commandButton(). */
 public function inventoryButton(int index) returns framehandle
-    return getFrame("InventoryButton_" + index)
+    if index < 0 or index > 5
+        return null
+    if inventoryButtonFrame[index] == null
+        inventoryButtonFrame[index] = getFrame("InventoryButton_" + index)
+    return inventoryButtonFrame[index]
 
 // --- Visibility helpers ----------------------------------------------------------
+// Each setter comes in two shapes:
+//   setXVisible(bool)            - every player.
+//   setXVisible(player, bool)    - ONE player. It acquires the handle for every client FIRST and only
+//                                  then applies the local visibility flag, so it is safe to call
+//                                  directly. Do NOT wrap it in a localPlayer block: that would move
+//                                  the handle acquisition into the local branch, which is the actual
+//                                  desync (see WC3_FRAMEHANDLE_GUIDE.md "Multiplayer Safety").
+// All of them tolerate a frame that does not exist on the running patch.
 
 /** Shows/hides the day/night dial. No-op (with a warning) before 1.32.6, where the dial is not
     reachable; there the only option is blanking its textures in gameplay interface settings. */
@@ -100,27 +127,81 @@ public function setDayNightClockVisible(bool visible)
     else if tableWarnings
         Log.warn("dayNightClock(): not reachable (needs WC3 1.32.6+); cannot change its visibility.")
 
+/** Shows/hides the day/night dial for ONE player. Safe to call directly; never wrap in localPlayer. */
+public function setDayNightClockVisible(player p, bool visible)
+    let clock = dayNightClock()
+    if clock != null
+        clock.setVisible(p, visible)
+    else if tableWarnings
+        Log.warn("dayNightClock(): not reachable (needs WC3 1.32.6+); cannot change its visibility.")
+
 public function hideDayNightClock()
     setDayNightClockVisible(false)
 
+public function hideDayNightClock(player p)
+    setDayNightClockVisible(p, false)
+
 public function setResourceBarVisible(bool visible)
-    resourceBar().setVisible(visible)
+    let frame = resourceBar()
+    if frame != null
+        frame.setVisible(visible)
+
+/** Shows/hides the resource bar for ONE player. Safe to call directly; never wrap in localPlayer. */
+public function setResourceBarVisible(player p, bool visible)
+    let frame = resourceBar()
+    if frame != null
+        frame.setVisible(p, visible)
 
 public function setUpperButtonBarVisible(bool visible)
-    upperButtonBar().setVisible(visible)
+    let frame = upperButtonBar()
+    if frame != null
+        frame.setVisible(visible)
+
+/** Shows/hides the Quests/Menu/Allies/Log bar for ONE player. Safe to call directly. */
+public function setUpperButtonBarVisible(player p, bool visible)
+    let frame = upperButtonBar()
+    if frame != null
+        frame.setVisible(p, visible)
 
 public function setMinimapVisible(bool visible)
-    minimapFrame().setVisible(visible)
+    let frame = minimapFrame()
+    if frame != null
+        frame.setVisible(visible)
     // The five filter buttons live in their own container next to the minimap; toggle it too.
-    let buttonBar = getFrame("MiniMapButtonBar") // in stdlib FramehandleDefaultNames upstream
+    let buttonBar = minimapButtonBar()
     if buttonBar != null
         buttonBar.setVisible(visible)
 
+/** Shows/hides the minimap and its filter buttons for ONE player. Safe to call directly. */
+public function setMinimapVisible(player p, bool visible)
+    let frame = minimapFrame()
+    if frame != null
+        frame.setVisible(p, visible)
+    let buttonBar = minimapButtonBar()
+    if buttonBar != null
+        buttonBar.setVisible(p, visible)
+
 public function setPortraitVisible(bool visible)
-    portraitFrame().setVisible(visible)
+    let frame = portraitFrame()
+    if frame != null
+        frame.setVisible(visible)
+
+/** Shows/hides the unit portrait for ONE player. Safe to call directly. */
+public function setPortraitVisible(player p, bool visible)
+    let frame = portraitFrame()
+    if frame != null
+        frame.setVisible(p, visible)
 
 public function setHeroBarVisible(bool visible)
-    heroBar().setVisible(visible)
+    let frame = heroBar()
+    if frame != null
+        frame.setVisible(visible)
+
+/** Shows/hides the left hero-icon stack for ONE player. Safe to call directly. */
+public function setHeroBarVisible(player p, bool visible)
+    let frame = heroBar()
+    if frame != null
+        frame.setVisible(p, visible)
 
 // --- Full custom-UI mode ----------------------------------------------------------
 
@@ -132,7 +213,12 @@ public function setHeroBarVisible(bool visible)
 
     Treat as ONE-WAY: re-showing everything afterwards is not reliable across patches (2.0.1
     cannot re-show the resource bar at all). Re-show single pieces with the setXVisible helpers
-    where supported. The world remains fully clickable where the console was. */
+    where supported. The world remains fully clickable where the console was.
+
+    MULTIPLAYER: this is NOT a per-player operation and has no player-scoped overload. It acquires
+    handles, reparents the ubertooltip and resizes the console backdrop - shared structural work that
+    must run identically on every client. Never call it inside a localPlayer block. To give one player
+    a different HUD, call this for everyone and then use the setXVisible(player, bool) overloads. */
 public function hideDefaultUi()
     // Stop the game re-positioning default frames on resolution/window changes.
     enableUIAutoPosition(false)
@@ -160,14 +246,17 @@ public function hideDefaultUi()
             bottomBar.hide()
 
 /** Touches every handle this package manages, once, synchronously - the handleId reservation
-    pattern. Call this at elapsed 0.00 for ALL players if you later show/hide default UI inside
-    localPlayer blocks (e.g. observer-only HUD); after reserving, local visibility changes cannot
-    desync handle counters. */
+    pattern. Call this at elapsed 0.00 for ALL players before any per-player default-UI work.
+
+    With the setXVisible(player, bool) overloads this is now belt-and-braces rather than load-bearing:
+    those acquire the handle for every client before applying the local flag. It stays the right call
+    when you reach past this package to a raw frame yourself, or hand-write a localPlayer block. */
 public function reserveDefaultUiHandles()
     dayNightClock()
     resourceBar()
     upperButtonBar()
     minimapFrame()
+    minimapButtonBar()
     portraitFrame()
     heroBar()
     getFrame(FramehandleDefaultNames.consoleUI)

--- a/wurst/components/TableUiDialog.wurst
+++ b/wurst/components/TableUiDialog.wurst
@@ -55,10 +55,10 @@ public class UIConfirmDialog
     function withModal(real opacity) returns thistype
         if modal == null
             modal = new UIModalBackdrop(Layer.DIALOG, MODAL_BARRIER_LEVEL, opacity)
-            modal.onClick() ->
+            modal.onClick() clicker ->
                 hide()
                 if listener != null
-                    listener.onCancel(GetTriggerPlayer())
+                    listener.onCancel(clicker)
         return this
 
     function create() returns framehandle
@@ -130,6 +130,24 @@ public class UIConfirmDialog
             modal.hide()
         return this
 
+    /** Shows or hides the dialog (and its modal backdrop) FOR ONE PLAYER. Creates the dialog on every
+        client first, then flips only that player's visibility flag - the safe shape for prompting a
+        single player. Never wrap this in a localPlayer block.
+        NOTE: the dialog is one shared instance, so the first click resolves it for whoever it is
+        visible to. For a prompt each player answers independently, build one per owner with
+        perPlayerFrames(). */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        if modal != null
+            modal.setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
     function getFrame() returns framehandle
         return create()
 
@@ -175,7 +193,7 @@ public class UIDialog
     function withModal(real opacity) returns thistype
         if modal == null
             modal = new UIModalBackdrop(Layer.DIALOG, MODAL_BARRIER_LEVEL, opacity)
-            modal.onClick() ->
+            modal.onClick() clicker ->
                 hide()
         return this
 
@@ -218,6 +236,25 @@ public class UIDialog
         if modal != null
             modal.hide()
         return this
+
+    /** Creates (once) the dialog on every client. Call this at elapsed 0.00 for all players when the
+        dialog is later shown per-player, so no allocation can ever happen inside a local block. */
+    function create() returns framehandle
+        return getFrame()
+
+    /** Shows or hides the dialog (and its modal backdrop) FOR ONE PLAYER. Creates it on every client
+        first, then flips only that player's visibility flag. Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag) returns thistype
+        getFrame().setVisible(p, flag)
+        if modal != null
+            modal.setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
 
     /** Returns a sized "X" button that calls hide() on this dialog (including its modal backdrop).
         Use this instead of closeButton(getFrame()) when a modal is attached, so the backdrop

--- a/wurst/components/TableUiInputs.wurst
+++ b/wurst/components/TableUiInputs.wurst
@@ -52,6 +52,19 @@ public class UIEditBox
     function getFrame() returns framehandle
         return create()
 
+    /** Shows or hides the edit box FOR ONE PLAYER. Allocates for every client first, then flips only
+        that player's visibility flag - the safe shape. Never wrap this in a localPlayer block.
+        NOTE: the typed text is local state by nature; read it only via onSubmit's synced `text`. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
 public function textInput(string initialText, real width) returns UIEditBox
     return new UIEditBox(initialText, width)
 

--- a/wurst/components/TableUiInputs.wurst
+++ b/wurst/components/TableUiInputs.wurst
@@ -56,7 +56,7 @@ public class UIEditBox
         that player's visibility flag - the safe shape. Never wrap this in a localPlayer block.
         NOTE: the typed text is local state by nature; read it only via onSubmit's synced `text`. */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiModal.wurst
+++ b/wurst/components/TableUiModal.wurst
@@ -38,8 +38,9 @@ constant DIM_STRIP_W = 0.4
 function namedChild(string name, int context) returns framehandle
     return getFrame(name, context)
 
+/** `p` is the player who clicked the barrier. */
 public interface ModalDismissCallback
-    function run()
+    function run(player p)
 
 /** Full-screen modal barrier: a click-catcher placed one level below its paired dialog or
     dropdown within a shared z-band.
@@ -113,10 +114,26 @@ public class UIModalBackdrop
             dimRight.hide()
         return this
 
+    /** Shows or hides the barrier (and the widescreen dim strips) FOR ONE PLAYER. Creates the frames
+        on every client first, then flips only that player's visibility flag - the safe shape.
+        Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        if dimLeft != null
+            dimLeft.setVisible(p, flag)
+            dimRight.setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
     /** Registers the callback fired when the barrier is clicked (outside the dialog/menu). */
     function onClick(ModalDismissCallback cb) returns thistype
         create()
         barrier.onClick() ->
             barrier.releaseKeyboardFocus(GetTriggerPlayer())
-            cb.run()
+            cb.run(GetTriggerPlayer())
         return this

--- a/wurst/components/TableUiPerPlayer.wurst
+++ b/wurst/components/TableUiPerPlayer.wurst
@@ -1,0 +1,119 @@
+package TableUiPerPlayer
+// One UI tree per player, allocated synchronously on every client.
+//
+// WHY THIS EXISTS: Warcraft III is lockstep. Frame HANDLES must be allocated in the same order on
+// every client; only the visibility flag may legally differ per player. The tempting shortcut
+//
+//     if localPlayer == p
+//         myDialog.show()          // <- allocates the dialog on ONE client
+//
+// desyncs, because the frames, their click triggers and their listener closures only exist for that
+// one player: the click event is synced and fires everywhere, but only that client resolves a
+// listener and runs the map's callback. This helper removes the whole class of mistake - it builds
+// one tree per owner for ALL clients, then exposes owner-scoped visibility as the only divergent
+// state.
+//
+//     UISlider array volume
+//
+//     let volumeUi = perPlayerFrames() owner ->
+//         let s = slider("Volume", 0.20, 0., 100.)
+//         volume[owner.getId()] = s
+//         return s.getFrame()
+//     volumeUi.showEach()          // every player sees their own copy, nobody sees anyone else's
+//
+// Build the tree in the factory and keep your own typed handles (as above); the returned object owns
+// only the roots and their visibility.
+import TableLayout
+import LinkedList
+
+/** Builds one owner's UI tree and returns its root frame. Runs once per owner on EVERY client. */
+public interface PerPlayerFrameFactory
+    function build(player owner) returns framehandle
+
+/** The per-owner roots produced by perPlayerFrames(). Visibility is the only per-player state here;
+    the frames themselves already exist on every client. */
+public class PerPlayerFrames
+    private constant owners = new LinkedList<player>()
+    private constant roots = new LinkedList<framehandle>()
+
+    /** Builds one root per owner, in the given order, on every client. */
+    construct(LinkedList<player> buildFor, PerPlayerFrameFactory factory)
+        for owner in buildFor
+            // The factory runs for EVERY owner on EVERY client - that is the whole point. A null root
+            // is recorded as "no tree for this owner" rather than stored, so get() and the visibility
+            // helpers stay null-safe; the factory must not decide this from client-local state.
+            let root = factory.build(owner)
+            if root != null
+                owners.add(owner)
+                roots.add(root)
+            else if tableWarnings
+                Log.warn("perPlayerFrames: the factory returned null for player "
+                    + (owner.getId() + 1) + "; no tree was registered for them.")
+
+    private function indexOf(player owner) returns int
+        var i = 0
+        for candidate in owners
+            if candidate == owner
+                return i
+            i++
+        return -1
+
+    /** That owner's root frame, or null when no tree was built for them. */
+    function get(player owner) returns framehandle
+        let i = indexOf(owner)
+        return i < 0 ? null : roots.get(i)
+
+    /** Shows or hides `owner`'s tree, TO THAT OWNER ONLY. The single legal per-player operation:
+        the frame already exists everywhere, so only the local visibility flag diverges. */
+    function setVisible(player owner, bool flag) returns thistype
+        let root = get(owner)
+        if root != null
+            root.setVisible(owner, flag)
+        return this
+
+    function show(player owner) returns thistype
+        return setVisible(owner, true)
+
+    function hide(player owner) returns thistype
+        return setVisible(owner, false)
+
+    /** Every owner sees their own tree and nobody else's. The usual "open the menu for everyone" call. */
+    function showEach() returns thistype
+        for owner in owners
+            setVisible(owner, true)
+        return this
+
+    /** Hides every owner's tree from its owner. */
+    function hideEach() returns thistype
+        for owner in owners
+            setVisible(owner, false)
+        return this
+
+    /** The owners a tree was built for, in build order. Do not mutate. */
+    function getOwners() returns LinkedList<player>
+        return owners
+
+    // Frees the wrapper lists only. Warcraft III frames are never destroyed in multiplayer
+    // (BlzDestroyFrame is banned); the roots stay allocated and hidden, ready for reuse.
+    ondestroy
+        for owner in owners
+            setVisible(owner, false)
+        destroy owners
+        destroy roots
+
+/** Builds one UI tree per currently ingame player, synchronously on every client, in slot order. */
+public function perPlayerFrames(PerPlayerFrameFactory factory) returns PerPlayerFrames
+    let ingame = new LinkedList<player>()
+    for i = 0 to bj_MAX_PLAYER_SLOTS - 1
+        let p = players[i]
+        if p.isIngame()
+            ingame.add(p)
+    let result = new PerPlayerFrames(ingame, factory)
+    destroy ingame
+    return result
+
+/** Builds one UI tree per listed owner (teams, observers, a hand-picked subset), synchronously on
+    every client, in list order. The list must be identical on every client - derive it from synced
+    state (slot/controller state, forces, map setup), never from a local value. */
+public function perPlayerFrames(LinkedList<player> owners, PerPlayerFrameFactory factory) returns PerPlayerFrames
+    return new PerPlayerFrames(owners, factory)

--- a/wurst/components/TableUiPerPlayer.wurst
+++ b/wurst/components/TableUiPerPlayer.wurst
@@ -24,26 +24,38 @@ package TableUiPerPlayer
 // Build the tree in the factory and keep your own typed handles (as above); the returned object owns
 // only the roots and their visibility.
 import TableLayout
-import LinkedList
+import ArrayList
 
 /** Builds one owner's UI tree and returns its root frame. Runs once per owner on EVERY client. */
 public interface PerPlayerFrameFactory
     function build(player owner) returns framehandle
 
 /** The per-owner roots produced by perPlayerFrames(). Visibility is the only per-player state here;
-    the frames themselves already exist on every client. */
+    the frames themselves already exist on every client.
+
+    Every root is hidden globally at construction, so a player only ever sees a tree that was
+    explicitly shown to them. The factory does not need to hide what it builds. */
 public class PerPlayerFrames
-    private constant owners = new LinkedList<player>()
-    private constant roots = new LinkedList<framehandle>()
+    // ArrayList, presized to the slot count: this is append-only with indexed lookup and never
+    // removes, which is exactly ArrayList's sweet spot, and presizing means one allocation and no
+    // resize copy. Iterate by index - ArrayList has no iterator by design.
+    private constant owners = new ArrayList<player>(bj_MAX_PLAYER_SLOTS)
+    private constant roots = new ArrayList<framehandle>(bj_MAX_PLAYER_SLOTS)
 
     /** Builds one root per owner, in the given order, on every client. */
-    construct(LinkedList<player> buildFor, PerPlayerFrameFactory factory)
-        for owner in buildFor
+    construct(ArrayList<player> buildFor, PerPlayerFrameFactory factory)
+        for i = 0 to buildFor.size() - 1
+            let owner = buildFor.get(i)
             // The factory runs for EVERY owner on EVERY client - that is the whole point. A null root
             // is recorded as "no tree for this owner" rather than stored, so get() and the visibility
             // helpers stay null-safe; the factory must not decide this from client-local state.
             let root = factory.build(owner)
             if root != null
+                // Hide GLOBALLY, on every client, before any owner-scoped call runs. A freshly created
+                // frame defaults to visible, and setVisible(owner, flag) only ever touches the owner's
+                // client - so without this every player would keep seeing every other owner's tree,
+                // since nothing would hide it for them. Owner-scoped show is the only reveal.
+                root.hide()
                 owners.add(owner)
                 roots.add(root)
             else if tableWarnings
@@ -51,11 +63,9 @@ public class PerPlayerFrames
                     + (owner.getId() + 1) + "; no tree was registered for them.")
 
     private function indexOf(player owner) returns int
-        var i = 0
-        for candidate in owners
-            if candidate == owner
+        for i = 0 to owners.size() - 1
+            if owners.get(i) == owner
                 return i
-            i++
         return -1
 
     /** That owner's root frame, or null when no tree was built for them. */
@@ -79,31 +89,32 @@ public class PerPlayerFrames
 
     /** Every owner sees their own tree and nobody else's. The usual "open the menu for everyone" call. */
     function showEach() returns thistype
-        for owner in owners
-            setVisible(owner, true)
+        for i = 0 to owners.size() - 1
+            setVisible(owners.get(i), true)
         return this
 
     /** Hides every owner's tree from its owner. */
     function hideEach() returns thistype
-        for owner in owners
-            setVisible(owner, false)
+        for i = 0 to owners.size() - 1
+            setVisible(owners.get(i), false)
         return this
 
     /** The owners a tree was built for, in build order. Do not mutate. */
-    function getOwners() returns LinkedList<player>
+    function getOwners() returns ArrayList<player>
         return owners
 
     // Frees the wrapper lists only. Warcraft III frames are never destroyed in multiplayer
     // (BlzDestroyFrame is banned); the roots stay allocated and hidden, ready for reuse.
+    // Hidden globally rather than per owner, so teardown leaves nothing visible on any client.
     ondestroy
-        for owner in owners
-            setVisible(owner, false)
+        for i = 0 to roots.size() - 1
+            roots.get(i).hide()
         destroy owners
         destroy roots
 
 /** Builds one UI tree per currently ingame player, synchronously on every client, in slot order. */
 public function perPlayerFrames(PerPlayerFrameFactory factory) returns PerPlayerFrames
-    let ingame = new LinkedList<player>()
+    let ingame = new ArrayList<player>(bj_MAX_PLAYER_SLOTS)
     for i = 0 to bj_MAX_PLAYER_SLOTS - 1
         let p = players[i]
         if p.isIngame()
@@ -115,5 +126,5 @@ public function perPlayerFrames(PerPlayerFrameFactory factory) returns PerPlayer
 /** Builds one UI tree per listed owner (teams, observers, a hand-picked subset), synchronously on
     every client, in list order. The list must be identical on every client - derive it from synced
     state (slot/controller state, forces, map setup), never from a local value. */
-public function perPlayerFrames(LinkedList<player> owners, PerPlayerFrameFactory factory) returns PerPlayerFrames
+public function perPlayerFrames(ArrayList<player> owners, PerPlayerFrameFactory factory) returns PerPlayerFrames
     return new PerPlayerFrames(owners, factory)

--- a/wurst/components/TableUiSelect.wurst
+++ b/wurst/components/TableUiSelect.wurst
@@ -13,6 +13,9 @@ import LinkedList
 public interface SelectListener
     function onSelect(player p, int index, string value)
 
+// Class member arrays need a literal size, so bj_MAX_PLAYER_SLOTS (28) is mirrored here.
+constant MAX_SLOTS = 28
+
 // Inner inset of the dropdown menu and the vertical gap between option buttons.
 constant MENU_PADDING = 0.003
 constant MENU_GAP_Y = 0.001
@@ -23,7 +26,9 @@ public class UISelect
     string placeholder = ""
     real width = 0.
     real optionHeight = 0.024
-    bool open = false
+    // Per player: the dropdown is a transient interaction and its menu sits outside the select's
+    // root, so one shared flag would leak (and steal) it between players. See setOpenFor().
+    private boolean array[MAX_SLOTS] openByPid
     int selectedIndex = -1
 
     framehandle root = null
@@ -120,7 +125,7 @@ public class UISelect
         // are above the barrier (OVERLAY_LEVEL-1) so they still receive their own click events.
         clickCatcher = new UIModalBackdrop(Layer.OVERLAY, OVERLAY_LEVEL - 1, 0.0)
         clickCatcher.onClick() clicker ->
-            setOpen(false)
+            setOpenFor(clicker, false)
         clickCatcher.create()
 
         defaultFrameParent = prevParent
@@ -137,11 +142,24 @@ public class UISelect
         destroy options
         destroy optionFrames
 
+    /** Toggles the dropdown for every player. */
     function toggle()
-        setOpen(not open)
+        setOpen(not isOpenForAnyone())
 
+    /** Toggles the dropdown for ONE player, independently of every other player. */
     function toggleFor(player p)
-        setOpenFor(p, not open)
+        setOpenFor(p, not isOpenFor(p))
+
+    /** Whether the dropdown is currently open for `p`. Derived from the synced open state, not from a
+        local frame getter, so it is safe to branch on. */
+    function isOpenFor(player p) returns bool
+        return p != null and openByPid[p.getId()]
+
+    function isOpenForAnyone() returns bool
+        for i = 0 to MAX_SLOTS - 1
+            if openByPid[i]
+                return true
+        return false
 
     function syncMenuOverlay()
         // menu is created in the OVERLAY band, so on open we only re-anchor it to the toggle and
@@ -154,31 +172,40 @@ public class UISelect
 
     /** Opens/closes the dropdown for every player. */
     function setOpen(bool flag)
-        setOpenFor(null, flag)
-
-    /** Opens the dropdown for ONE player (null = everyone), closing always applies to everyone.
-
-        The menu deliberately lives in the OVERLAY band, OUTSIDE this select's root, so that it renders
-        above panels - which also means root visibility does not cover it. Opening it globally would
-        therefore put one player's dropdown on every screen, and on an owner-scoped select it would
-        show the menu to players who cannot even see the select. Opening it only for the acting player
-        is both the correct per-player behaviour and better shared-UI behaviour. */
-    function setOpenFor(player p, bool flag)
         create()
-        if flag == open
+        for i = 0 to MAX_SLOTS - 1
+            openByPid[i] = flag
+        applyOpen(null, flag)
+
+    /** Opens/closes the dropdown for ONE player (null = everyone).
+
+        Open state is tracked PER PLAYER because the menu lives in the OVERLAY band, OUTSIDE this
+        select's root: root visibility does not cover it, so a single shared flag meant one player's
+        dropdown appeared on every screen - and on an owner-scoped select it appeared for players who
+        cannot see the select at all. Per-player state also keeps a shared select usable by several
+        players at once: B opening their menu no longer closes A's. */
+    function setOpenFor(player p, bool flag)
+        if p == null
+            setOpen(flag)
             return
-        open = flag
-        if open
+        create()
+        if openByPid[p.getId()] == flag
+            return
+        openByPid[p.getId()] = flag
+        applyOpen(p, flag)
+
+    // Runs on every client; only the setVisible calls are player-scoped, and the geometry work below
+    // is identical everywhere, so no client diverges in anything but the visibility flag.
+    private function applyOpen(player p, bool flag)
+        if flag
             syncMenuOverlay()
             menu.setVisible(p, true)
             optionFrames.forEach(option -> option.setVisible(p, true))
             clickCatcher.setVisible(p, true)
         else
-            // Closing is unconditional: hiding a frame nobody can see is a harmless no-op, and it
-            // guarantees no client is left with a stale open menu.
-            clickCatcher.hide()
-            optionFrames.forEach(option -> option.hide())
-            menu.hide()
+            clickCatcher.setVisible(p, false)
+            optionFrames.forEach(option -> option.setVisible(p, false))
+            menu.setVisible(p, false)
             menuBackdrop.setAllPoints(menu)
 
     /** Shows or hides the select FOR ONE PLAYER. Creates it on every client first, then flips only
@@ -186,9 +213,9 @@ public class UISelect
         NOTE: the selected option stays shared - a pick by any player changes it for everyone. For an
         independent choice per player, build one UISelect per owner with perPlayerFrames(). */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         if not flag
-            setOpen(false)
+            setOpenFor(p, false)
         return this
 
     function show(player p) returns thistype
@@ -207,7 +234,7 @@ public class UISelect
         selectedIndex = index
         let value = options.get(index)
         toggleButton.setText(value)
-        setOpen(false)
+        setOpenFor(p, false)
         if listener != null
             listener.onSelect(p, index, value)
 

--- a/wurst/components/TableUiSelect.wurst
+++ b/wurst/components/TableUiSelect.wurst
@@ -155,9 +155,12 @@ public class UISelect
     function isOpenFor(player p) returns bool
         return p != null and openByPid[p.getId()]
 
+    /** Whether any real client currently has the dropdown open. Empty, AI and departed slots are
+        skipped: they can never open or close the menu themselves, so a flag left over from a global
+        setOpen(true) would otherwise report an invisible menu as open forever. */
     function isOpenForAnyone() returns bool
         for i = 0 to MAX_SLOTS - 1
-            if openByPid[i]
+            if openByPid[i] and players[i].isIngame()
                 return true
         return false
 
@@ -174,7 +177,12 @@ public class UISelect
     function setOpen(bool flag)
         create()
         for i = 0 to MAX_SLOTS - 1
-            openByPid[i] = flag
+            // Only real client slots get an open flag. Marking all 28 left empty and AI slots stuck at
+            // true once every actual player had closed their own menu, so isOpenForAnyone() reported an
+            // invisible menu as open and the next toggle() closed those stale flags instead of
+            // reopening. Slot and controller state are lockstep values, so this stays identical on
+            // every client.
+            openByPid[i] = flag and players[i].isIngame()
         applyOpen(null, flag)
 
     /** Opens/closes the dropdown for ONE player (null = everyone).

--- a/wurst/components/TableUiSelect.wurst
+++ b/wurst/components/TableUiSelect.wurst
@@ -9,8 +9,9 @@ import TableUiLayers
 import TableUiModal
 import LinkedList
 
+/** `p` is the player who picked the option, or null when the change came from selectOption(index). */
 public interface SelectListener
-    function onSelect(int index, string value)
+    function onSelect(player p, int index, string value)
 
 // Inner inset of the dropdown menu and the vertical gap between option buttons.
 constant MENU_PADDING = 0.003
@@ -105,7 +106,7 @@ public class UISelect
                 ..hide()
             option.onClick() ->
                 option.releaseKeyboardFocus(GetTriggerPlayer())
-                selectOption(index)
+                selectOption(GetTriggerPlayer(), index)
             optionFrames.add(option)
             menuLayout..row()..add(option)
 
@@ -116,7 +117,7 @@ public class UISelect
         // the dropdown and closes it. The menu (OVERLAY_LEVEL) and its options (OVERLAY_LEVEL+1)
         // are above the barrier (OVERLAY_LEVEL-1) so they still receive their own click events.
         clickCatcher = new UIModalBackdrop(Layer.OVERLAY, OVERLAY_LEVEL - 1, 0.0)
-        clickCatcher.onClick() ->
+        clickCatcher.onClick() clicker ->
             setOpen(false)
         clickCatcher.create()
 
@@ -162,7 +163,27 @@ public class UISelect
             menu.hide()
             menuBackdrop.setAllPoints(menu)
 
+    /** Shows or hides the select FOR ONE PLAYER. Creates it on every client first, then flips only
+        that player's visibility flag - the safe shape. Never wrap this in a localPlayer block.
+        NOTE: the selected option stays shared - a pick by any player changes it for everyone. For an
+        independent choice per player, build one UISelect per owner with perPlayerFrames(). */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        if not flag
+            setOpen(false)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
+    /** Selects an option programmatically (no acting player). */
     function selectOption(int index)
+        selectOption(null, index)
+
+    function selectOption(player p, int index)
         if index < 0 or index >= options.size()
             return
         selectedIndex = index
@@ -170,7 +191,7 @@ public class UISelect
         toggleButton.setText(value)
         setOpen(false)
         if listener != null
-            listener.onSelect(index, value)
+            listener.onSelect(p, index, value)
 
 public function select(string placeholder, real width) returns UISelect
     return new UISelect(placeholder, width)

--- a/wurst/components/TableUiSelect.wurst
+++ b/wurst/components/TableUiSelect.wurst
@@ -73,7 +73,9 @@ public class UISelect
             ..setAllPoints(root)
         toggleButton.onClick() ->
             toggleButton.releaseKeyboardFocus(GetTriggerPlayer())
-            toggle()
+            // Only the acting player gets the menu. A hidden toggle receives no clicks, so on an
+            // owner-scoped select this is always the owner.
+            toggleFor(GetTriggerPlayer())
 
         // The dropdown lives in the OVERLAY band so it floats above content and the HUD; it is anchored
         // to the toggle by point, so it needs no shared parent with root. The menu must be tall enough
@@ -138,6 +140,9 @@ public class UISelect
     function toggle()
         setOpen(not open)
 
+    function toggleFor(player p)
+        setOpenFor(p, not open)
+
     function syncMenuOverlay()
         // menu is created in the OVERLAY band, so on open we only re-anchor it to the toggle and
         // refresh levels: no reparenting (which could misalign the option buttons' hit areas).
@@ -147,17 +152,30 @@ public class UISelect
         menuBackdrop.setLevel(OVERLAY_LEVEL)
         optionFrames.forEach(option -> option.setLevel(OVERLAY_LEVEL + 1))
 
+    /** Opens/closes the dropdown for every player. */
     function setOpen(bool flag)
+        setOpenFor(null, flag)
+
+    /** Opens the dropdown for ONE player (null = everyone), closing always applies to everyone.
+
+        The menu deliberately lives in the OVERLAY band, OUTSIDE this select's root, so that it renders
+        above panels - which also means root visibility does not cover it. Opening it globally would
+        therefore put one player's dropdown on every screen, and on an owner-scoped select it would
+        show the menu to players who cannot even see the select. Opening it only for the acting player
+        is both the correct per-player behaviour and better shared-UI behaviour. */
+    function setOpenFor(player p, bool flag)
         create()
         if flag == open
             return
         open = flag
         if open
             syncMenuOverlay()
-            menu.show()
-            optionFrames.forEach(option -> option.show())
-            clickCatcher.show()
+            menu.setVisible(p, true)
+            optionFrames.forEach(option -> option.setVisible(p, true))
+            clickCatcher.setVisible(p, true)
         else
+            // Closing is unconditional: hiding a frame nobody can see is a harmless no-op, and it
+            // guarantees no client is left with a stale open menu.
             clickCatcher.hide()
             optionFrames.forEach(option -> option.hide())
             menu.hide()

--- a/wurst/components/TableUiSelectable.wurst
+++ b/wurst/components/TableUiSelectable.wurst
@@ -9,11 +9,13 @@ import TableUiButtons
 import TableUiTooltip
 import LinkedList
 
+/** `p` is the player who clicked, or null when the state came from setSelected(). */
 public interface SelectableListener
-    function onSelect(bool selected)
+    function onSelect(player p, bool selected)
 
+/** `p` is the player who clicked, or null when the selection came from select(chosen). */
 public interface SelectableGroupListener
-    function onSelect(int index)
+    function onSelect(player p, int index)
 
 /** General-purpose interaction directive for display-only frames: whole-frame hover/click plus an
     optional disabled scrim. Click + disable only by DEFAULT - a selected/active border is opt-in via
@@ -117,11 +119,11 @@ public class UISelectable
         overlay.onClick() ->
             overlay.releaseKeyboardFocus(GetTriggerPlayer())
             if ownerGroup != null
-                ownerGroup.select(this)
+                ownerGroup.select(GetTriggerPlayer(), this)
             else
                 setSelected(not selectedState)
             if listener != null
-                listener.onSelect(selectedState)
+                listener.onSelect(GetTriggerPlayer(), selectedState)
 
     /** Shows or hides the selection border. */
     function setSelected(bool flag)
@@ -161,8 +163,12 @@ public class UISelectableGroup
         members.add(sel)
         return sel
 
-    /** Selects `chosen`, clears the others, and fires the group listener with its index. */
+    /** Selects `chosen` programmatically (no acting player), clears the others, and fires the group
+        listener with its index. */
     function select(UISelectable chosen)
+        select(null, chosen)
+
+    function select(player p, UISelectable chosen)
         var index = 0
         var chosenIndex = -1
         for sel in members
@@ -172,7 +178,7 @@ public class UISelectableGroup
                 chosenIndex = index
             index++
         if listener != null and chosenIndex >= 0
-            listener.onSelect(chosenIndex)
+            listener.onSelect(p, chosenIndex)
 
     /** Clears all selection in the group. */
     function clearSelection()

--- a/wurst/components/TableUiSimple.wurst
+++ b/wurst/components/TableUiSimple.wurst
@@ -84,7 +84,7 @@ public class UISimpleBar
     /** Shows or hides the bar FOR ONE PLAYER. Creates it on every client first, then flips only that
         player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype
@@ -163,7 +163,7 @@ public class UISimpleTexture
         that player's visibility flag - the safe shape. Never wrap this in a localPlayer block.
         Only the main frame is toggled; the fragile Texture child is never touched. */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiSimple.wurst
+++ b/wurst/components/TableUiSimple.wurst
@@ -81,6 +81,18 @@ public class UISimpleBar
     function getFrame() returns framehandle
         return create()
 
+    /** Shows or hides the bar FOR ONE PLAYER. Creates it on every client first, then flips only that
+        player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
     // Hides the frame and frees the wrapper. The frame is pooled (hidden), never destroyed,
     // matching the library's MP-safe hide/reuse convention.
     ondestroy
@@ -146,6 +158,19 @@ public class UISimpleTexture
     /** The main SimpleFrame: safe for show/hide and positioning. Do NOT add it to a TableLayout. */
     function getFrame() returns framehandle
         return create()
+
+    /** Shows or hides the texture FOR ONE PLAYER. Creates it on every client first, then flips only
+        that player's visibility flag - the safe shape. Never wrap this in a localPlayer block.
+        Only the main frame is toggled; the fragile Texture child is never touched. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
 
     // Hides the frame and frees the wrapper. The frame is pooled (hidden), never destroyed.
     // The fragile Texture child is left untouched (visibility natives can crash on it).

--- a/wurst/components/TableUiSliders.wurst
+++ b/wurst/components/TableUiSliders.wurst
@@ -3,8 +3,9 @@ package TableUiSliders
 import TableLayout
 import TableUiText
 
+/** `p` is the player whose drag produced the value, or null when the change came from setValue(). */
 public interface SliderListener
-    function onChange(real value)
+    function onChange(player p, real value)
 
 /** A labelled value slider on WC3's native SLIDER: [label] [====O====] [value]. Set the range in the
     constructor, tune step/decimals, read getValue(), and react with onChange(); the value text and
@@ -82,12 +83,23 @@ public class UISlider
             ..setTextAlignment(TEXT_JUSTIFY_MIDDLE, TEXT_JUSTIFY_RIGHT)
 
         valueChangeFrameListener = sliderFrame.onSliderValueChange() ->
+            // The event itself is synced (every client gets the same BlzGetTriggerFrameValue), but a
+            // DRAG only moved the knob on the dragging client's machine - no script call touched the
+            // others. Without the re-assert below, remote clients show the new number against a stale
+            // knob. Re-asserting brings the knob into the synced half, leaving visibility as the only
+            // per-player state. Re-entry terminates: the re-fired event carries the same value, so
+            // `changed` is false and this branch is skipped.
+            let programmatic = syncingValue
             let nextValue = BlzGetTriggerFrameValue()
             let changed = nextValue != value
             value = nextValue
             valueFrame.setText(format(value))
-            if changed and not syncingValue and listener != null
-                listener.onChange(value)
+            if changed and not programmatic
+                syncingValue = true
+                sliderFrame.setValue(value)
+                syncingValue = false
+                if listener != null
+                    listener.onChange(GetTriggerPlayer(), value)
 
         let layout = new TableLayout(width, height, "Slider")
         layout.padding = padding(0, 0, 0, 0)
@@ -111,6 +123,18 @@ public class UISlider
 
     function getFrame() returns framehandle
         return create()
+
+    /** Shows or hides the slider FOR ONE PLAYER. Allocates for every client first, then flips only
+        that player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
+    function setVisible(player p, bool flag) returns thistype
+        create().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
 
 public function slider(string label, real width, real minValue, real maxValue) returns UISlider
     return new UISlider(label, width, minValue, maxValue)

--- a/wurst/components/TableUiSliders.wurst
+++ b/wurst/components/TableUiSliders.wurst
@@ -127,7 +127,7 @@ public class UISlider
     /** Shows or hides the slider FOR ONE PLAYER. Allocates for every client first, then flips only
         that player's visibility flag - the safe shape. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag) returns thistype
-        create().setVisible(p, flag)
+        create().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiSyncCheck.wurst
+++ b/wurst/components/TableUiSyncCheck.wurst
@@ -17,42 +17,69 @@ package TableUiSyncCheck
 import TableLayout
 import ArrayList
 import SyncSimple
+import ClosureTimers
 
 /** Reports the outcome of checkUiSync(). `ok` is false when at least one player's UI allocation
-    count differs from the others. */
+    count differs from the others, or when a player never answered. */
 public interface UiSyncReport
     function onResult(bool ok, string detail)
 
+/** How long to wait for every player's count before giving up and reporting what arrived. A player
+    who leaves mid-check never transmits, so without this the check would hang forever. */
+public var uiSyncTimeout = 10.
+
 int array countByPid
 bool array reportedByPid
+bool array awaitedByPid
 var pending = 0
-var expected = 0
+// Bumped per check so a late or post-timeout sync callback from an earlier run is ignored instead of
+// driving `pending` negative and firing a second, bogus finish().
+var checkEpoch = 0
 UiSyncReport activeListener = null
 
 function finish()
     var reference = -1
     var referencePid = -1
-    var ok = true
+    var answered = 0
+    // Kept apart on purpose: a genuine count DIVERGENCE means a frame tree was built in a local block
+    // and is an error, whereas a MISSING answer just means someone left mid-check. Reporting the
+    // second as the first would send people hunting a desync that is not there.
+    var mismatch = false
     var detail = ""
+    var missing = ""
     for i = 0 to bj_MAX_PLAYER_SLOTS - 1
         if reportedByPid[i]
+            answered++
             if reference < 0
                 reference = countByPid[i]
                 referencePid = i
             else if countByPid[i] != reference
-                ok = false
+                mismatch = true
             detail += "P" + (i + 1) + "=" + countByPid[i] + " "
-    if not ok
+        else if awaitedByPid[i]
+            missing += "P" + (i + 1) + " "
+    pending = 0
+    if missing != ""
+        detail += "(no answer: " + missing.trim() + ")"
+
+    if mismatch
         Log.error("checkUiSync: UI allocation counts DIFFER between players (" + detail.trim()
             + "). A frame tree was created inside a localPlayer block; allocate for all clients and"
             + " use the player-scoped show/hide overloads instead.")
+    else if missing != ""
+        Log.warn("checkUiSync: no count arrived from " + missing.trim() + " within " + uiSyncTimeout
+            + "s (they most likely left mid-check). The " + answered
+            + " count(s) that did arrive agree; the check is inconclusive, not failed.")
+    else if answered == 0
+        Log.warn("checkUiSync: no ingame players to check.")
     else if tableWarnings
-        Log.info("checkUiSync: UI allocation counts agree across " + expected
+        Log.info("checkUiSync: UI allocation counts agree across " + answered
             + " player(s) (" + reference + " via P" + (referencePid + 1) + ").")
+
     let listener = activeListener
     activeListener = null
     if listener != null
-        listener.onResult(ok, detail.trim())
+        listener.onResult(not mismatch and missing == "", detail.trim())
         destroy listener
 
 /** Asks every ingame player for their library UI allocation count and logs an error naming the
@@ -68,15 +95,20 @@ public function checkUiSync(UiSyncReport listener)
             destroy listener
         return
 
+    checkEpoch++
+    let epoch = checkEpoch
+    // isIngame() is slot PLAYING *and* controller MAP_CONTROL_USER, so computer slots are already
+    // excluded - only real clients can transmit through SyncSimple.
     let participants = new ArrayList<player>(bj_MAX_PLAYER_SLOTS)
     for i = 0 to bj_MAX_PLAYER_SLOTS - 1
         reportedByPid[i] = false
+        awaitedByPid[i] = false
         countByPid[i] = 0
         if players[i].isIngame()
             participants.add(players[i])
+            awaitedByPid[i] = true
 
-    expected = participants.size()
-    pending = expected
+    pending = participants.size()
     activeListener = listener
 
     if pending == 0
@@ -90,9 +122,17 @@ public function checkUiSync(UiSyncReport listener)
         // Evaluated on every client, but SyncSimple only lets `p` transmit, so every client receives
         // p's local count. Allocation happens here, globally - never inside a local block.
         uiAllocationCount().sync(p) value ->
-            countByPid[pid] = value
-            reportedByPid[pid] = true
-            pending--
-            if pending == 0
-                finish()
+            if epoch == checkEpoch and not reportedByPid[pid]
+                countByPid[pid] = value
+                reportedByPid[pid] = true
+                pending--
+                if pending == 0
+                    finish()
     destroy participants
+
+    // A player who leaves after the request is queued never transmits, so pending would never reach
+    // zero: the listener would never fire and the `pending > 0` guard would reject every later check
+    // for the rest of the game. Time out instead and report whoever answered.
+    doAfter(uiSyncTimeout) ->
+        if epoch == checkEpoch and pending > 0
+            finish()

--- a/wurst/components/TableUiSyncCheck.wurst
+++ b/wurst/components/TableUiSyncCheck.wurst
@@ -1,0 +1,97 @@
+package TableUiSyncCheck
+// OPT-IN desync detector for UI allocation. Deliberately NOT re-exported by the TableUi facade:
+// importing it registers stdlib sync events, so only maps that want the check pay for it.
+//
+// The failure it catches is the one the library cannot prevent for you: a frame tree built inside a
+// localPlayer block. Every client must allocate the same number of library containers/components, so
+// this asks each player for their uiAllocationCount() and reports any player whose count differs.
+//
+//     import TableUiSyncCheck
+//     ...
+//     doAfter(5.) -> checkUiSync()      // logs an error naming any divergent player
+//
+// This is a DIAGNOSTIC. It runs asynchronously (the counts arrive over the network a moment later)
+// and its result must never drive game logic - only logging. It detects divergence in library
+// container/component allocation (layoutFrame / nextUiContext), which is what per-player UI is made
+// of; a bare p()/img()/btn() created inside a local block is not counted.
+import TableLayout
+import LinkedList
+import SyncSimple
+
+/** Reports the outcome of checkUiSync(). `ok` is false when at least one player's UI allocation
+    count differs from the others. */
+public interface UiSyncReport
+    function onResult(bool ok, string detail)
+
+int array countByPid
+bool array reportedByPid
+var pending = 0
+var expected = 0
+UiSyncReport activeListener = null
+
+function finish()
+    var reference = -1
+    var referencePid = -1
+    var ok = true
+    var detail = ""
+    for i = 0 to bj_MAX_PLAYER_SLOTS - 1
+        if reportedByPid[i]
+            if reference < 0
+                reference = countByPid[i]
+                referencePid = i
+            else if countByPid[i] != reference
+                ok = false
+            detail += "P" + (i + 1) + "=" + countByPid[i] + " "
+    if not ok
+        Log.error("checkUiSync: UI allocation counts DIFFER between players (" + detail.trim()
+            + "). A frame tree was created inside a localPlayer block; allocate for all clients and"
+            + " use the player-scoped show/hide overloads instead.")
+    else if tableWarnings
+        Log.info("checkUiSync: UI allocation counts agree across " + expected
+            + " player(s) (" + reference + " via P" + (referencePid + 1) + ").")
+    let listener = activeListener
+    activeListener = null
+    if listener != null
+        listener.onResult(ok, detail.trim())
+        destroy listener
+
+/** Asks every ingame player for their library UI allocation count and logs an error naming the
+    counts when they disagree. Diagnostic only; the result arrives asynchronously. */
+public function checkUiSync()
+    checkUiSync(null)
+
+/** checkUiSync() with a callback for the outcome. Do not branch game logic on the result. */
+public function checkUiSync(UiSyncReport listener)
+    if pending > 0
+        Log.warn("checkUiSync: a check is already in flight; ignoring this call.")
+        if listener != null
+            destroy listener
+        return
+
+    let participants = new LinkedList<player>()
+    for i = 0 to bj_MAX_PLAYER_SLOTS - 1
+        reportedByPid[i] = false
+        countByPid[i] = 0
+        if players[i].isIngame()
+            participants.add(players[i])
+
+    expected = participants.size()
+    pending = expected
+    activeListener = listener
+
+    if pending == 0
+        destroy participants
+        finish()
+        return
+
+    for p in participants
+        let pid = p.getId()
+        // Evaluated on every client, but SyncSimple only lets `p` transmit, so every client receives
+        // p's local count. Allocation happens here, globally - never inside a local block.
+        uiAllocationCount().sync(p) value ->
+            countByPid[pid] = value
+            reportedByPid[pid] = true
+            pending--
+            if pending == 0
+                finish()
+    destroy participants

--- a/wurst/components/TableUiSyncCheck.wurst
+++ b/wurst/components/TableUiSyncCheck.wurst
@@ -15,7 +15,7 @@ package TableUiSyncCheck
 // container/component allocation (layoutFrame / nextUiContext), which is what per-player UI is made
 // of; a bare p()/img()/btn() created inside a local block is not counted.
 import TableLayout
-import LinkedList
+import ArrayList
 import SyncSimple
 
 /** Reports the outcome of checkUiSync(). `ok` is false when at least one player's UI allocation
@@ -68,7 +68,7 @@ public function checkUiSync(UiSyncReport listener)
             destroy listener
         return
 
-    let participants = new LinkedList<player>()
+    let participants = new ArrayList<player>(bj_MAX_PLAYER_SLOTS)
     for i = 0 to bj_MAX_PLAYER_SLOTS - 1
         reportedByPid[i] = false
         countByPid[i] = 0
@@ -84,7 +84,8 @@ public function checkUiSync(UiSyncReport listener)
         finish()
         return
 
-    for p in participants
+    for i = 0 to participants.size() - 1
+        let p = participants.get(i)
         let pid = p.getId()
         // Evaluated on every client, but SyncSimple only lets `p` transmit, so every client receives
         // p's local count. Allocation happens here, globally - never inside a local block.

--- a/wurst/components/TableUiTabs.wurst
+++ b/wurst/components/TableUiTabs.wurst
@@ -91,6 +91,20 @@ public class UITabs
     function getFrame() returns framehandle
         return build()
 
+    /** Shows or hides the whole tab container FOR ONE PLAYER. Builds for every client first, then
+        flips only that player's visibility flag. Never wrap this in a localPlayer block.
+        NOTE: which TAB is active stays shared - a click by any player switches it for everyone. For
+        genuinely independent tabs per player, build one UITabs per owner with perPlayerFrames(). */
+    function setVisible(player p, bool flag) returns thistype
+        build().setVisible(p, flag)
+        return this
+
+    function show(player p) returns thistype
+        return setVisible(p, true)
+
+    function hide(player p) returns thistype
+        return setVisible(p, false)
+
     // Frees the title/content/button lists. Frames are shared and MP-sensitive, so they are not
     // destroyed here (hide/reuse instead); this just releases the wrapper lists.
     ondestroy

--- a/wurst/components/TableUiTabs.wurst
+++ b/wurst/components/TableUiTabs.wurst
@@ -96,7 +96,7 @@ public class UITabs
         NOTE: which TAB is active stays shared - a click by any player switches it for everyone. For
         genuinely independent tabs per player, build one UITabs per owner with perPlayerFrames(). */
     function setVisible(player p, bool flag) returns thistype
-        build().setVisible(p, flag)
+        build().setVisibleForOwner(p, flag)
         return this
 
     function show(player p) returns thistype

--- a/wurst/components/TableUiTooltip.wurst
+++ b/wurst/components/TableUiTooltip.wurst
@@ -54,11 +54,13 @@ public class UITooltip
     function getFrame() returns framehandle
         return box
 
-    // Detaches the tooltip from its owner and hides its frames. The box/text frames are pooled (hidden),
-    // not destroyed, matching the library's MP-safe hide/reuse convention; this frees the wrapper object.
+    // Hides the tooltip frames and frees the wrapper object. The box/text frames are pooled (hidden),
+    // not destroyed, matching the library's MP-safe hide/reuse convention.
+    //
+    // The owner/tooltip association is deliberately NOT cleared: setTooltip cannot really be undone
+    // (WC3_FRAMEHANDLE_GUIDE.md "Tooltips"), and re-setting the pair is the documented way to crash on
+    // hover. Hiding the box is what actually stops the tooltip from rendering, so that is all we do.
     ondestroy
-        if owner != null
-            owner.setTooltip(null)
         if box != null
             box.hide()
         if textFrame != null


### PR DESCRIPTION
Follow-up to a desync audit of the library. The library's own code was clean — no `GetLocalPlayer`, no `BlzDestroyFrame`, no gameplay natives outside `MultiboardAttach`, and input already read through the synced `BlzGetTriggerFrame*` accessors. What it lacked was a way for a *consumer* to express "only this player sees it" without writing the unsafe thing themselves.

## The hole this closes

Every component allocated lazily from its presentation methods (`show()`, `setOpen()`, `placeAt()`, `withTooltip()`), and there were no player-scoped overloads. So the natural line to write was:

```wurst
if localPlayer == p
    dialog.show()          // creates frames, click triggers and listener closures on ONE client
```

That is not cosmetic. Frame events are synced, so the button's click fires on every client — but only the client that ran `create()` resolves a listener in `ClosureFrames`, so the map's callback executes on exactly one machine. A local branch reaching a synchronized sink.

## Library

- **Player-scoped overloads everywhere.** `show(player)` / `hide(player)` / `setVisible(player, bool)` on `UIConfirmDialog`, `UIDialog`, `UIModalBackdrop`, `UISelect`, `UISlider`, `UIEditBox`, `UITabs`, `UIBar`, `UIStatBar`, `UICheckbox`, `UISimpleBar`, `UISimpleTexture`. Each calls `create()` unconditionally, *then* applies the local flag — allocation is on the safe side of the guard by construction.
- **`TableUiDefaultUi` gains `setXVisible(player, bool)`** for the whole HUD, so per-player HUD work no longer depends on remembering `reserveDefaultUiHandles()` (which stays, now belt-and-braces). Also fixes the global setters dereferencing a null frame on patches where it doesn't exist, and caches command/inventory buttons like the other getters.
- **New `TableUiPerPlayer`** — `perPlayerFrames(factory)` builds one tree per owner on every client in owner order, and exposes owner-scoped visibility. For UI each player owns independently.
- **New `TableUiSyncCheck`** (opt-in; deliberately *not* re-exported by the facade, since importing it registers stdlib sync events) — `checkUiSync()` syncs each player's UI allocation count and logs an error naming any player whose count differs.
- **Listeners pass the acting player first**, matching `TextInputListener` / `ConfirmDialogListener` which already did.

## Two defects found in the same pass

- **`UISlider` knob drift.** The handler updated `value` and the value text from the synced event but never the knob. A drag moves the knob only on the dragging client, so everyone else saw the new number against a stale knob. The handler now re-asserts the knob on all clients, bringing that widget state into the synced half. Re-entry terminates because the re-fired event carries the same value (`changed == false`) — safe whether the engine fires `SLIDER_VALUE_CHANGED` synchronously or deferred.
- **`UITooltip.ondestroy` called `setTooltip(null)`**, contradicting this repo's own rule ([`WC3_FRAMEHANDLE_GUIDE.md`](WC3_FRAMEHANDLE_GUIDE.md): "`setTooltip` cannot really be undone", and re-setting a pair can crash on hover). It now only hides the box, which is what actually stops it rendering.

`MultiboardAttach` is documented as global-only: unlike the rest of the library it mutates synchronized multiboard state (`MultiboardSetRowCount` / `MultiboardSetItemsStyle`) and creates a timer on first attach.

## Breaking change

Listener interfaces take a leading `player` (null when the change was programmatic rather than a click):

| Interface | Before | After |
| --- | --- | --- |
| `SliderListener` | `onChange(real)` | `onChange(player, real)` |
| `SelectListener` | `onSelect(int, string)` | `onSelect(player, int, string)` |
| `SelectableListener` | `onSelect(bool)` | `onSelect(player, bool)` |
| `SelectableGroupListener` | `onSelect(int)` | `onSelect(player, int)` |
| `CheckboxListener` | `onChange(boolean)` | `onChange(player, boolean)` |
| `ModalDismissCallback` | `run()` | `run(player)` |

Migration is adding the parameter. `UISelect.selectOption(index)` and `UISelectableGroup.select(chosen)` keep their old arity as programmatic overloads that pass `null`.

## Validation

- `grill typecheck --quiet` — passes.
- `grill test` — 78/78, zero compiler warnings.
- **Stage 2 (WC3 run) still required.** `TableLayoutTest.wurst` gains a `perPlayerFrames` demo panel: each player should see exactly one card naming themselves (in a single-player run, only P1's). `PerPlayerFrames` has no headless test on purpose — the compiletime interpreter cannot represent a framehandle (it treats a null one as non-null), so a test would have meant contorting library code to satisfy the harness. Its build contract needs the real run.
- The desync claims here are **static source-to-sink paths**, not observed desyncs. No multiplayer or replay divergence evidence was gathered; the slider knob drift in particular wants a two-client confirmation.


## Review follow-ups

- **`PerPlayerFrames` roots were visible by default** (caught in review). A fresh frame defaults to visible and `setVisible(owner, flag)` only touches the owner's client, so nothing hid owner B's tree on owner A's screen — `showEach()` showed *every* tree to *every* player. Roots are now hidden globally at construction, so owner-scoped show is the only reveal.
- **`UISelect`'s dropdown had the same bug one level down.** The menu lives in the OVERLAY band, outside the select's root, so root visibility never covered it: one player opening a dropdown put it on every screen, and on an owner-scoped select it leaked the menu to players who cannot see the select. Opening is now scoped to the acting player (`setOpenFor`); a hidden toggle receives no clicks, so on an owner-scoped select that is always the owner. Closing stays unconditional. This is better shared-UI behaviour too — a transient dropdown never belonged on everyone's screen.
- **`LinkedList` → `ArrayList`** in `PerPlayerFrames` and the sync check, presized to the slot count. Append-only with indexed lookup and no removal anywhere is the case `ArrayList` documents itself for; presizing gives one allocation and no resize copy. Iteration is by index (`ArrayList` has no iterator by design). Note this needs a `wurstStdlib2` new enough to have `ArrayList` — CI already resolves `master`, so no manifest change was required.
