### PR TITLE
Scope dialog dismissal to how the dialog was shown

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -328,8 +328,10 @@ To prompt a single player, use the player-scoped overload - never a `localPlayer
 dialog.show(p)          // created for every client, visible only to p
 ```
 
-The dialog is still one shared instance, so the first click resolves it and `onAccept(p)` reports who
-clicked. When each player must answer independently, give each their own (see below).
+Dismissal follows that scope: shown with `show(p)`, the outside click / Yes / No / `closeButton()`
+close it for the acting player only; shown globally with `show()`, they close it for everyone. The
+dialog is still one shared instance, so `onAccept(p)` reports who clicked and the LAST answer wins on
+shared state. When each player must answer independently, give each their own (see below).
 
 ### Per-player UI
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ let picker = perPlayerFrames() owner ->
 picker.showEach()                   // each player sees their own, nobody sees anyone else's
 ```
 
+Dialog dismissal follows the same scope. `withModal()`'s outside click, the Yes/No buttons and
+`UIDialog.closeButton()` close the dialog for the **acting player** when it was shown per player
+(`show(p)`), and for everyone when it was shown globally (`show()`) — so a shared prompt still
+resolves once for all, while a private one cannot be closed out from under the other players.
+
 `import TableUiSyncCheck` and call `checkUiSync()` to verify: it asks every player for their UI
 allocation count and logs an error naming any player whose count differs. It is a diagnostic - never
 branch game logic on it.

--- a/wurst/TableLayoutTest.wurst
+++ b/wurst/TableLayoutTest.wurst
@@ -104,6 +104,15 @@ function buildComponentsPanel(UIConfirmDialog confirm, UIDialog custom)
     customButton.onClick() ->
         customButton.releaseKeyboardFocus(GetTriggerPlayer())
         custom.show()
+    // Per-player prompt. MULTIPLAYER check (cannot be seen single-player): the dialog opens only for
+    // the player who clicked, and dismissing it - via the dim, Yes/No - closes it for that player
+    // alone. The "Confirm" button above still opens the same dialog globally, where dismissing it
+    // closes it for everyone; the scope follows how it was shown.
+    let privateButton = textButton("Private", 0.058, 0.024)
+        ..withTooltip("Open the confirm dialog for the clicking player only.")
+    privateButton.onClick() ->
+        privateButton.releaseKeyboardFocus(GetTriggerPlayer())
+        confirm.show(GetTriggerPlayer())
 
     let layout = new TableLayout(cw, ch, "Components")
     layout.padding = padding(PANEL_BORDER_INSET, PANEL_BORDER_INSET, PANEL_BORDER_INSET, PANEL_BORDER_INSET)
@@ -119,6 +128,7 @@ function buildComponentsPanel(UIConfirmDialog confirm, UIDialog custom)
     // Click repeatedly: visibility toggles must not accelerate the autocast animation.
     ..row()..add(label("Autocast", NAME_W))..add(autocastButton)
     ..row()..add(label("Dialogs", NAME_W))..add(confirmButton)..add(customButton)
+    ..row()..add(label("Per-player", NAME_W))..add(privateButton)
     ..row()..middle()..add(label("Text area", NAME_W))..add(textArea(NOTES_TEXT, 0.13, 0.064))
     layout.applyTo(root)
     defaultFrameParent = prev

--- a/wurst/components/TableUiDialog.wurst
+++ b/wurst/components/TableUiDialog.wurst
@@ -27,6 +27,10 @@ public class UIConfirmDialog
     framehandle frame = null
     ConfirmDialogListener listener = null
     UIModalBackdrop modal = null
+    // Set once the dialog has been shown/hidden per player. Dismissal then follows the same scope:
+    // a shared dialog closes for everyone (one decision, made once), a per-player prompt closes only
+    // for whoever answered it. Without this, one player clicking the dim closed the prompt for all.
+    private var ownerScoped = false
 
     construct(string title, string message)
         this.title = title
@@ -48,7 +52,9 @@ public class UIConfirmDialog
         return this
 
     /** Attaches a dark full-screen backdrop that dims the scene behind the dialog and closes it
-        (firing onCancel) on any outside click. Call before show(). Default opacity: 0.8. */
+        (firing onCancel) on any outside click. Call before show(). Default opacity: 0.8.
+        The outside click closes the dialog for the CLICKING player when it was shown per player
+        (show(p)), or for everyone when it was shown globally (show()). */
     function withModal() returns thistype
         return withModal(MODAL_DEFAULT_OPACITY)
 
@@ -56,10 +62,18 @@ public class UIConfirmDialog
         if modal == null
             modal = new UIModalBackdrop(Layer.DIALOG, MODAL_BARRIER_LEVEL, opacity)
             modal.onClick() clicker ->
-                hide()
+                dismissFor(clicker)
                 if listener != null
                     listener.onCancel(clicker)
         return this
+
+    /** Closes the dialog for `p` alone when it was shown per player, or for everyone when it was
+        shown globally. Answering a prompt only you can see must not close it for the others. */
+    private function dismissFor(player p)
+        if ownerScoped and p != null
+            hide(p)
+        else
+            hide()
 
     function create() returns framehandle
         if frame != null
@@ -90,13 +104,13 @@ public class UIConfirmDialog
 
         accept.onClick() ->
             accept.releaseKeyboardFocus(GetTriggerPlayer())
-            hide()
+            dismissFor(GetTriggerPlayer())
             if listener != null
                 listener.onAccept(GetTriggerPlayer())
 
         cancel.onClick() ->
             cancel.releaseKeyboardFocus(GetTriggerPlayer())
-            hide()
+            dismissFor(GetTriggerPlayer())
             if listener != null
                 listener.onCancel(GetTriggerPlayer())
 
@@ -180,13 +194,17 @@ public class UIDialog
     private real height
     private framehandle frame = null
     private UIModalBackdrop modal = null
+    // See UIConfirmDialog.ownerScoped: dismissal follows how the dialog was shown.
+    private var ownerScoped = false
 
     construct(real width, real height)
         this.width = width
         this.height = height
 
     /** Attaches a dark full-screen backdrop that dims the scene behind the dialog and closes it
-        on any outside click. Call before show(). Default opacity: 0.8. */
+        on any outside click. Call before show(). Default opacity: 0.8.
+        The outside click closes the dialog for the CLICKING player when it was shown per player
+        (show(p)), or for everyone when it was shown globally (show()). */
     function withModal() returns thistype
         return withModal(MODAL_DEFAULT_OPACITY)
 
@@ -194,8 +212,16 @@ public class UIDialog
         if modal == null
             modal = new UIModalBackdrop(Layer.DIALOG, MODAL_BARRIER_LEVEL, opacity)
             modal.onClick() clicker ->
-                hide()
+                dismissFor(clicker)
         return this
+
+    /** Closes the dialog for `p` alone when it was shown per player, or for everyone when it was
+        shown globally. */
+    private function dismissFor(player p)
+        if ownerScoped and p != null
+            hide(p)
+        else
+            hide()
 
     /** Creates (once) the dialog backdrop on the DIALOG layer and returns it, hidden. */
     function getFrame() returns framehandle
@@ -256,9 +282,10 @@ public class UIDialog
     function hide(player p) returns thistype
         return setVisible(p, false)
 
-    /** Returns a sized "X" button that calls hide() on this dialog (including its modal backdrop).
-        Use this instead of closeButton(getFrame()) when a modal is attached, so the backdrop
-        is dismissed together with the panel. */
+    /** Returns a sized "X" button that closes this dialog (including its modal backdrop). Use this
+        instead of closeButton(getFrame()) when a modal is attached, so the backdrop is dismissed
+        together with the panel. Closes for the clicking player when the dialog was shown per player,
+        for everyone when it was shown globally. */
     function closeButton() returns framehandle
         return closeButton(0.018)
 
@@ -266,7 +293,7 @@ public class UIDialog
         let btn = textButton("X", size, size)
         btn.onClick() ->
             btn.releaseKeyboardFocus(GetTriggerPlayer())
-            hide()
+            dismissFor(GetTriggerPlayer())
         return btn
 
     /** Positions the dialog's TOPLEFT, clamped into the safe area (clear of the melee HUD). */

--- a/wurst/components/TableUiDialog.wurst
+++ b/wurst/components/TableUiDialog.wurst
@@ -132,6 +132,8 @@ public class UIConfirmDialog
         return frame
 
     function show() returns thistype
+        // Shown to everyone, so dismissal goes back to closing it for everyone.
+        ownerScoped = false
         create().show()
         if modal != null
             modal.show()
@@ -151,6 +153,9 @@ public class UIConfirmDialog
         visible to. For a prompt each player answers independently, build one per owner with
         perPlayerFrames(). */
     function setVisible(player p, bool flag) returns thistype
+        // Records that this dialog is being driven per player, so dismissFor() closes it for the
+        // acting player instead of everyone. A later global show() clears it again.
+        ownerScoped = true
         create().setVisible(p, flag)
         if modal != null
             modal.setVisible(p, flag)
@@ -251,6 +256,8 @@ public class UIDialog
         return f
 
     function show() returns thistype
+        // Shown to everyone, so dismissal goes back to closing it for everyone.
+        ownerScoped = false
         getFrame().show()
         if modal != null
             modal.show()
@@ -271,6 +278,9 @@ public class UIDialog
     /** Shows or hides the dialog (and its modal backdrop) FOR ONE PLAYER. Creates it on every client
         first, then flips only that player's visibility flag. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag) returns thistype
+        // Records that this dialog is being driven per player, so dismissFor() closes it for the
+        // acting player instead of everyone. A later global show() clears it again.
+        ownerScoped = true
         getFrame().setVisible(p, flag)
         if modal != null
             modal.setVisible(p, flag)

--- a/wurst/components/TableUiDialog.wurst
+++ b/wurst/components/TableUiDialog.wurst
@@ -153,9 +153,14 @@ public class UIConfirmDialog
         visible to. For a prompt each player answers independently, build one per owner with
         perPlayerFrames(). */
     function setVisible(player p, bool flag) returns thistype
-        // Records that this dialog is being driven per player, so dismissFor() closes it for the
-        // acting player instead of everyone. A later global show() clears it again.
-        ownerScoped = true
+        // Only a scoped SHOW switches the dismissal mode: that is what establishes a per-player
+        // presentation, so dismissFor() then closes for the acting player instead of everyone. A
+        // scoped HIDE must leave the mode alone - hiding a globally shown dialog from one player
+        // (an observer, say) does not make it a per-player prompt, and flipping the mode there would
+        // let a remaining player's Yes close only their own copy and fire the result again and again.
+        // A later global show() clears the mode.
+        if flag
+            ownerScoped = true
         create().setVisible(p, flag)
         if modal != null
             modal.setVisible(p, flag)
@@ -278,9 +283,10 @@ public class UIDialog
     /** Shows or hides the dialog (and its modal backdrop) FOR ONE PLAYER. Creates it on every client
         first, then flips only that player's visibility flag. Never wrap this in a localPlayer block. */
     function setVisible(player p, bool flag) returns thistype
-        // Records that this dialog is being driven per player, so dismissFor() closes it for the
-        // acting player instead of everyone. A later global show() clears it again.
-        ownerScoped = true
+        // Only a scoped SHOW switches the dismissal mode; a scoped hide preserves the mode of the
+        // active presentation. See UIConfirmDialog.setVisible for the reasoning.
+        if flag
+            ownerScoped = true
         getFrame().setVisible(p, flag)
         if modal != null
             modal.setVisible(p, flag)


### PR DESCRIPTION
Follow-up to #6. Closes the gap `wurst-castle-fight` had already worked around in `RoundStatsBoard.wurst`:

> *Not `UIDialog.withModal()`: that wires an outside-click handler calling the dialog's own global `hide()`, which would close the board for EVERY player when one of them clicks the dim.*

That comment was accurate. `withModal()`'s dismiss handler, the confirm dialog's Yes/No buttons and `UIDialog.closeButton()` all called the **global** `hide()`, so one player dismissing closed the dialog for everyone — which made the `show(p)` overload added in #6 unusable together with a modal.

## Approach

Rather than pick one scope for both cases, dismissal now follows **how the dialog was shown**:

- shown globally with `show()` → dismissing closes it for everyone (unchanged);
- shown per player with `show(p)` → dismissing closes it for that player alone.

`setVisible(player, bool)` sets an `ownerScoped` flag and `dismissFor(p)` branches on it. A shared prompt therefore keeps resolving once for all — correct when the dialog represents a single decision — while a private prompt cannot be closed out from under the other players. `ModalDismissCallback` already carries the acting player from #6, so no new plumbing was needed.

Applies to all three dismissal paths: the modal outside-click, `UIConfirmDialog`'s Yes/No, and `UIDialog.closeButton()`.

## Compatibility

The only behaviour that changes is for dialogs shown per player, which was not expressible before #6, so nothing existing can depend on it. Verified against both consuming maps: **neither uses `withModal()` or `UIDialog.closeButton()`** — zombie-defense uses the free `closeButton(frame, size)` from `TableUiButtons`, which is untouched. Inert for them until they adopt it.

## Validation

Stage 1 (this repo's gate):

- `grill typecheck --quiet` — passes.
- `grill test` — full suite green, zero compiler warnings.
- `git diff --check` — clean.
- The demo panel gained a row, so its fit was re-checked headlessly with a throwaway `inspect()` model before committing: **0.368 required of 0.380 available**, empty overflow summary. Scratch file removed.

Stage 2 (engine evidence) — **not run, and not runnable here.** This repo has no e2e harness of its own; per `AGENTS.md` that gate belongs to a consuming map. `TableLayoutTest.wurst` gains a **"Private"** button that opens the confirm dialog for the clicking player only, so the scenario is ready to click, but the behaviour this PR changes is per-player dismissal — **it cannot be observed with one client**. The real check needs two clients: P1 opens via "Private", P2 must not see it; P1 clicks the dim, and the dialog must close for P1 only. The pre-existing "Confirm" button covers the global path in the same run.

Treat this as unverified against the engine until that run happens.
